### PR TITLE
Added OpenAPI 3.1 and its referenceable components using best design approach for eth_call API

### DIFF
--- a/ethereum/CommonProperties.yaml
+++ b/ethereum/CommonProperties.yaml
@@ -1,0 +1,9 @@
+title: CommonProperties
+type: object
+properties:
+  id:
+    type: integer
+    default: 1
+  jsonrpc:
+    type: string
+    default: '2.0'

--- a/ethereum/EVM Smart Contract Execution/eth_call.yaml
+++ b/ethereum/EVM Smart Contract Execution/eth_call.yaml
@@ -1,0 +1,37 @@
+openapi: 3.1.0
+x-stoplight:
+  id: 0f28dd778c214
+info:
+  title: Message Call
+  description: Executes a new message call immediately without creating a transaction on the block chain.
+  version: '1.0'
+servers:
+  - url: 'https://eth-mainnet.alchemyapi.io/v2'
+    variables:
+      apiKey:
+        default: demo
+paths:
+  '/{apiKey}':
+    post:
+      operationId: eth_call
+      summary: Message Call
+      description: Executes a new message call immediately without creating a transaction on the block chain..
+      parameters:
+        - name: apiKey
+          in: path
+          schema:
+            type: string
+            default: demo
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ./eth_call_body.yaml
+      responses:
+        '200':
+          description: Click to see response payload
+          content:
+            application/json:
+              schema:
+                $ref: ./eth_call_response.yaml

--- a/ethereum/EVM Smart Contract Execution/eth_call.yaml
+++ b/ethereum/EVM Smart Contract Execution/eth_call.yaml
@@ -1,6 +1,4 @@
 openapi: 3.1.0
-x-stoplight:
-  id: 0f28dd778c214
 info:
   title: Message Call
   description: Executes a new message call immediately without creating a transaction on the block chain.
@@ -15,7 +13,7 @@ paths:
     post:
       operationId: eth_call
       summary: Message Call
-      description: Executes a new message call immediately without creating a transaction on the block chain..
+      description: Executes a new message call immediately without creating a transaction on the block chain.
       parameters:
         - name: apiKey
           in: path
@@ -30,7 +28,7 @@ paths:
               $ref: ./eth_call_body.yaml
       responses:
         '200':
-          description: Click to see response payload
+          description: The return value of executed contract.
           content:
             application/json:
               schema:

--- a/ethereum/EVM Smart Contract Execution/eth_call_body.yaml
+++ b/ethereum/EVM Smart Contract Execution/eth_call_body.yaml
@@ -1,0 +1,38 @@
+allOf:
+  - $ref: ../CommonProperties.yaml
+  - type: object
+    properties:
+      method:
+        type: string
+        default: eth_call
+        enum:
+          - eth_call
+      params:
+        type: array
+        minItems: 1
+        maxItems: 1
+        items:
+          type: object
+          properties:
+            from:
+              type: string
+              description: 20 Bytes - The address the transaction is sent from.
+            to:
+              type: string
+              description: 20 Bytes - The address the transaction is directed to
+            gas:
+              type: string
+              description: 'Integer of the gas provided for the transaction execution. eth_call consumes zero gas, but this parameter may be needed by some executions. NOTE: this parameter has a cap of 550 Million gas per request. Reach out to us at support@alchemy.com if you want to increase this limit!'
+            gasPrice:
+              type: string
+              description: Integer of the gasPrice used for each paid gas.
+            value:
+              type: string
+              description: Integer of the value sent with this transaction
+            data:
+              type: string
+              description: Hash of the method signature and encoded parameters
+          required:
+            - to
+x-stoplight:
+  id: d128b48720336

--- a/ethereum/EVM Smart Contract Execution/eth_call_body.yaml
+++ b/ethereum/EVM Smart Contract Execution/eth_call_body.yaml
@@ -1,3 +1,4 @@
+title: eth_call_body
 allOf:
   - $ref: ../CommonProperties.yaml
   - type: object
@@ -34,5 +35,3 @@ allOf:
               description: Hash of the method signature and encoded parameters
           required:
             - to
-x-stoplight:
-  id: d128b48720336

--- a/ethereum/EVM Smart Contract Execution/eth_call_response.yaml
+++ b/ethereum/EVM Smart Contract Execution/eth_call_response.yaml
@@ -1,0 +1,7 @@
+title: eth_call_response
+allOf:
+  - $ref: ../CommonProperties.yaml
+  - type: object
+    properties:
+      result:
+        type: string


### PR DESCRIPTION
Here I have designed a structure for overall project where we will have multiple directories (each for an API category, "EVM Smart Contract Execution" in our case since eth_call is a part of this category) and inside these individual directories we will have OpenAPI spec file with method_name.yaml and corresponding request body and response schema models. This way we will build our whole project. 
If you have any questions, feel free to ask.