### PR TITLE
Update assetTransfers contract addresses field type

### DIFF
--- a/body.yaml
+++ b/body.yaml
@@ -2312,8 +2312,10 @@ getAssetTransfers_eth_mainnet:
       type: string
       description: String - To address (hex string). Default wildcard - any address
     contractAddresses:
-      type: string
+      type: array
       description: 'String - List of contract addresses (hex strings) to filter for - only applies to "token", "erc20", "erc721", "erc1155" transfers. Default wildcard - any address'
+      items:
+        type: string
     category:
       type: array
       description: |

--- a/body.yaml
+++ b/body.yaml
@@ -2313,7 +2313,7 @@ getAssetTransfers_eth_mainnet:
       description: String - To address (hex string). Default wildcard - any address
     contractAddresses:
       type: array
-      description: 'String - List of contract addresses (hex strings) to filter for - only applies to "token", "erc20", "erc721", "erc1155" transfers. Default wildcard - any address'
+      description: 'String - List of contract addresses (hex strings) to filter for - only applies to "erc20", "erc721", "erc1155" transfers. Default wildcard - any address'
       items:
         type: string
     category:


### PR DESCRIPTION
Change the contract addresses field in assetTransfers API to array of strings.