### PR TITLE
Validate blockNumber for alchemy_getTransactionReceipts

### DIFF
--- a/body.yaml
+++ b/body.yaml
@@ -967,6 +967,7 @@ alchemy_getTransactionReceipts_param:
               blockNumber:
                 type: string
                 description: The block number you want to get transaction receipts for, in hex
+                pattern: '^0[xX][0-9a-fA-F]+$'
               blockHash:
                 type: string
                 description: The block hash you want to get transaction receipts for


### PR DESCRIPTION
Use `pattern` keyword to ensure blockNumber is valid hex value.
[Data types - string](https://swagger.io/docs/specification/data-models/data-types/#string)