### PR TITLE
Incorrect types and labeling on request response

### DIFF
--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -428,8 +428,7 @@ components:
               type: object
               properties:
                 after:
-                  type: string
-                  description: 'Page cursor for the next page.'
+                  $ref: '#/components/schemas/after'
             total_count:
               type: integer
               description: 'Total number of addresses.'
@@ -465,8 +464,7 @@ components:
               type: object
               properties:
                 after:
-                  type: string
-                  description: 'Page cursor for the next page.'
+                  $ref: '#/components/schemas/after'
             total_count:
               type: integer
               description: 'Total number of nft filters.'

--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -332,7 +332,7 @@ components:
           type: boolean
           description: '(boolean) - true if webhook is active, false if not active.'
         time_created:
-          type: string
+          type: integer
           description: 'Timestamp webhook was created.'
         addresses:
           type: array
@@ -375,7 +375,9 @@ components:
             cursors:
               type: object
               properties:
-                $ref: '#/components/schemas/after'
+                after:
+                  type: string
+                  description: 'Page cursor for the next page.'
             total_count:
               type: integer
               description: 'Total number of addresses.'
@@ -410,7 +412,9 @@ components:
             cursors:
               type: object
               properties:
-                $ref: '#/components/schemas/after'
+                after:
+                  type: string
+                  description: 'Page cursor for the next page.'
             total_count:
               type: integer
               description: 'Total number of nft filters.'

--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -210,7 +210,7 @@ components:
       name: after
       schema:
         type: string
-        default: '5'
+        default: '1'
       description: 'Page cursor for the next page.'
       in: query
     nft_filter_object:


### PR DESCRIPTION
1. time_created is listed as a string type, but the returned time is a number type that represents number of seconds since epoch
2. The schema field should be after based on the response payload