### PR TITLE
Get all webhooks docs clarification

### DIFF
--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -8,7 +8,7 @@ paths:
   /team-webhooks:
     get:
       summary: Get all webhooks
-      description: This endpoint allows you to get all webhooks from every app on your team.
+      description: This endpoint allows you to get all webhooks on your team.
       tags: ['Notify API Endpoints']
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'

--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -7,7 +7,7 @@ servers:
 paths:
   /team-webhooks:
     get:
-      summary: Get all webhooks
+      summary: Get all webhooks on your team
       description: This endpoint allows you to get all webhooks on your team.
       tags: ['Notify API Endpoints']
       parameters:

--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -7,7 +7,7 @@ servers:
 paths:
   /team-webhooks:
     get:
-      summary: Get all webhooks on your team
+      summary: Get all webhooks
       description: This endpoint allows you to get all webhooks on your team.
       tags: ['Notify API Endpoints']
       parameters:


### PR DESCRIPTION
The description reads: “This endpoint allows you to get all webhooks from every app on your team.”
Since webhooks are not always tied with apps we should rename to `Get all webhooks on your team.`