### PR TITLE
Update addresses and filters missing default param

### DIFF
--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -259,11 +259,13 @@ components:
           description: 'ID of the address activity webhook'
         addresses_to_add:
           type: array
+          default: []
           description: 'List of addresses to add, use [] if none.'
           items:
             type: string
         addresses_to_remove:
           type: array
+          default: []
           description: 'List of addresses to remove, use [] if none.'
           items:
             type: string
@@ -277,11 +279,13 @@ components:
           description: 'ID of the address activity webhook'
         nft_filters_to_add:
           type: array
+          default: []
           description: 'List of nft filters to add, use [] if none.'
           items:
             $ref: '#/components/schemas/nft_filter_object'
         nft_filters_to_remove:
           type: array
+          default: []
           description: 'List of addresses to remove, use [] if none.'
           items:
             $ref: '#/components/schemas/nft_filter_object'


### PR DESCRIPTION
When  updating Nft/Address Activity webhooks, specifying to only one of the two add and remove fields. The generated curl request doesn’t work however, since the endpoint requires passing in an empty array if there are no fields present.