### PR TITLE
Added OpenAPI specs for all the missing methods in NFT API docs.

### DIFF
--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -166,7 +166,7 @@ eth_getBlockTransactionCountByNumber:
               - type: string
                 title: block number or block tag
                 default: finalized
-            
+
 eth_getTransactionCount:
   allOf:
     - $ref: '#/common_request_fields'
@@ -431,25 +431,25 @@ eth_feeHistory:
           minItems: 3
           maxItems: 3
           description: |
-              1. `integer` - Block count or range
-              2. `string` - Block number (in hex) or block tag
-              3. `array` of `integers` - (optional) Reward percentiles to sample from each block
+            1. `integer` - Block count or range
+            2. `string` - Block number (in hex) or block tag
+            3. `array` of `integers` - (optional) Reward percentiles to sample from each block
           items:
             anyOf:
-            - type: integer
-              title: Block count
-              description: Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query (may return less than requested range if not all blocks are available).
-              default: 4
-            - $ref: '#/blockNumber_or_blocktag_param_eth'
-              title: Newest block
-              description: highest number block in the requested range
-              default: latest
-            - type: array
-              items:
-                type: number
-              title: reward percentiles
-              description: (optional) A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used.
-              default: [25,75]
+              - type: integer
+                title: Block count
+                description: Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query (may return less than requested range if not all blocks are available).
+                default: 4
+              - $ref: '#/blockNumber_or_blocktag_param_eth'
+                title: Newest block
+                description: highest number block in the requested range
+                default: latest
+              - type: array
+                items:
+                  type: number
+                title: reward percentiles
+                description: (optional) A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used.
+                default: [25, 75]
 eth_maxPriorityFeePerGas:
   allOf:
     - $ref: '#/common_request_fields'
@@ -746,8 +746,8 @@ alchemy_getTokenBalances:
           items:
             type: string
             default: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-            
-alchemy_getTokenMetadata: 
+
+alchemy_getTokenMetadata:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
@@ -793,7 +793,7 @@ trace_call:
                 description: transaction object.
               - $ref: '#/trace_type_array'
               - $ref: '#/blockNumber_or_blocktag_param_eth'
-                title: Block number or block tag 
+                title: Block number or block tag
 trace_rawTransaction:
   allOf:
     - $ref: '#/common_request_fields'
@@ -816,7 +816,7 @@ trace_rawTransaction:
               - type: string
                 title: raw transaction
                 description: Raw transaction data.
-                default: "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
+                default: '0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675'
               - $ref: '#/trace_type_array'
 trace_replayBlockTransactions:
   allOf:
@@ -864,7 +864,7 @@ trace_replayTransaction:
                 default: '0x8fc90a6c3ee3001cdcbbb685b4fbe67b1fa2bec575b15b0395fea5540d0901ae'
                 pattern: '^0[xX][0-9a-fA-F]+$'
               - $ref: '#/trace_type_array'
-              
+
 trace_block:
   allOf:
     - $ref: '#/common_request_fields'
@@ -904,12 +904,12 @@ trace_filter:
               fromBlock:
                 type: string
                 description: From this block
-                default: "0xc26f54"
+                default: '0xc26f54'
                 pattern: '^0[xX][0-9a-fA-F]+$'
               toBlock:
                 type: string
                 description: To this block
-                default: "0xc26f54"
+                default: '0xc26f54'
                 pattern: '^0[xX][0-9a-fA-F]+$'
               fromAddress:
                 type: string
@@ -925,7 +925,7 @@ trace_filter:
               count:
                 type: integer
                 description: Integer number of traces to display in a batch.
-                
+
 trace_get:
   allOf:
     - $ref: '#/common_request_fields'
@@ -945,17 +945,17 @@ trace_get:
           maxItems: 2
           items:
             anyOf:
-            - type: string
-              title: Transaction hash
-              default: '0x8fc90a6c3ee3001cdcbbb685b4fbe67b1fa2bec575b15b0395fea5540d0901ae'
-              pattern: '^0[xX][0-9a-fA-F]+$'
-            - type: array
-              title: index position of trace
-              description: Array - Index positions of the traces, in hex
-              items:
-                type: string
+              - type: string
+                title: Transaction hash
+                default: '0x8fc90a6c3ee3001cdcbbb685b4fbe67b1fa2bec575b15b0395fea5540d0901ae'
                 pattern: '^0[xX][0-9a-fA-F]+$'
-              default: ["0x0"]
+              - type: array
+                title: index position of trace
+                description: Array - Index positions of the traces, in hex
+                items:
+                  type: string
+                  pattern: '^0[xX][0-9a-fA-F]+$'
+                default: ['0x0']
 
 trace_transaction:
   allOf:
@@ -1085,11 +1085,11 @@ eth_createAccessList:
           maxItems: 2
           items:
             anyOf:
-            - $ref: '#/transaction_object'
-              title: Transaction object
-            - $ref: '#/blockNumber_or_blocktag_param_l2'
-              title: Block number or block tag
-              default: pending
+              - $ref: '#/transaction_object'
+                title: Transaction object
+              - $ref: '#/blockNumber_or_blocktag_param_l2'
+                title: Block number or block tag
+                default: pending
 
 # ============= Transfers API Methods ===============
 alchemy_getAssetTransfers:
@@ -1146,7 +1146,7 @@ alchemy_getAssetTransfers:
                     - erc721
                     - erc1155
                     - specialnft
-                default: ["external"]
+                default: ['external']
               order:
                 type: string
                 description: |
@@ -1200,31 +1200,31 @@ debug_traceCall:
           description: |
             1. `object` - Transaction Object
             2. `string` - Block Identifier: Block hash, block number (in hex), or block tag
-            3. `tracer` - Object: Currently only supports `callTracer` (see above for definition)
+            3. `tracer` - Object: Currently supports `callTracer` and `prestateTracer` (see above for definitions).
           items:
             anyOf:
-            - $ref: '#/transaction_object'
-              title: Transaction object
-            - type: string
-              title: Block identifier
-              description: |
-                String - One of the following options:
-                  1. **block hash**
-                  2. **block number** (in hex)
-                  3. **block tag** (one of the following):
-                    * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
-                    * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
-                    * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
-                    * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
-                    * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
-              default: finalized
-            - type: object
-              title: Tracer
-              properties:
-                tracer:
-                  $ref: '#/tracer'
-                tracerConfig:
-                  $ref: '#/tracerConfig'
+              - $ref: '#/transaction_object'
+                title: Transaction object
+              - type: string
+                title: Block identifier
+                description: |
+                  String - One of the following options:
+                    1. **block hash**
+                    2. **block number** (in hex)
+                    3. **block tag** (one of the following):
+                      * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
+                      * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
+                      * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
+                      * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
+                      * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
+                default: finalized
+              - type: object
+                title: Tracer
+                properties:
+                  tracer:
+                    $ref: '#/tracer'
+                  tracerConfig:
+                    $ref: '#/tracerConfig'
 
 debug_traceBlockByHash:
   allOf:
@@ -1240,22 +1240,22 @@ debug_traceBlockByHash:
           type: array
           description: |
             1. `string` - Block hash for the block to be traced
-            2. `tracer` Object - Currently only supports `callTracer` (see above for definition)
+            2. `tracer` Object - Currently supports `callTracer` and `prestateTracer` (see above for definitions).
           minItems: 2
           maxItems: 2
           items:
             anyOf:
-            - type: string
-              title: Block hash
-              description: block hash
-              default: '0x7bd8357213af34d3fe7f725d9b21187a5a58127e39aac5776fd0594e3391ea6e'
-            - type: object
-              title: Tracer
-              properties:
-                tracer:
-                  $ref: '#/tracer'
-                tracerConfig:
-                  $ref: '#/tracerConfig'
+              - type: string
+                title: Block hash
+                description: block hash
+                default: '0x7bd8357213af34d3fe7f725d9b21187a5a58127e39aac5776fd0594e3391ea6e'
+              - type: object
+                title: Tracer
+                properties:
+                  tracer:
+                    $ref: '#/tracer'
+                  tracerConfig:
+                    $ref: '#/tracerConfig'
 debug_traceBlockByNumber:
   allOf:
     - $ref: '#/common_request_fields'
@@ -1270,7 +1270,7 @@ debug_traceBlockByNumber:
           type: array
           description: |
             1. String - Block number (in hex) or block tag
-            2. `tracer` Object - Currently only supports `callTracer` (see above for definition).
+            2. `tracer` Object - Currently supports `callTracer` and `prestateTracer` (see above for definitions).
           minItems: 2
           maxItems: 2
           items:
@@ -1301,23 +1301,23 @@ debug_traceTransaction:
           description: |
             1. String - Transaction hash
             2. Object - options for call, can be any of the following options:
-              - `tracer`: Object - Currently only supports `callTracer` (see above for definition).
+              - `tracer`: Object - Currently supports `callTracer` and `prestateTracer` (see above for definitions).
               - `timeout`: String - A duration string of decimal numbers that overrides the default timeout of 5 seconds for JavaScript-based tracing calls. Max timeout is "10s". Valid time units are "ns", "us", "ms", "s" each with optional fraction, such as "300ms" or "2s45ms".
           items:
             anyOf:
-            - $ref: '#/transactionHash_param'
-            - type: object
-              description: options for call
-              title: Options
-              properties:
-                tracer:
-                  $ref: '#/tracer'
-                tracerConfig:
-                  $ref: '#/tracerConfig'
-                timeout:
-                  type: string
-                  description: A duration string of decimal numbers that overrides the default timeout of 5 seconds for JavaScript-based tracing calls. Max timeout is "10s". Valid time units are "ns", "us", "ms", "s" each with optional fraction, such as "300ms" or "2s45ms".
-                  default: 5s
+              - $ref: '#/transactionHash_param'
+              - type: object
+                description: options for call
+                title: Options
+                properties:
+                  tracer:
+                    $ref: '#/tracer'
+                  tracerConfig:
+                    $ref: '#/tracerConfig'
+                  timeout:
+                    type: string
+                    description: A duration string of decimal numbers that overrides the default timeout of 5 seconds for JavaScript-based tracing calls. Max timeout is "10s". Valid time units are "ns", "us", "ms", "s" each with optional fraction, such as "300ms" or "2s45ms".
+                    default: 5s
 
 # ============ EVM Models ==============
 common_request_fields:
@@ -1466,7 +1466,7 @@ get_signed_txns_status_param:
       maxItems: 1
       items:
         type: string
-        default: "0x000C"
+        default: '0x000C'
 bundled_signed_transaction_param:
   type: object
   properties:
@@ -1534,8 +1534,7 @@ trace_type_array:
     enum:
       - trace
       - stateDiff
-  default: ["trace"]
-
+  default: ['trace']
 
 # ======= Definitions for blockNumber methods ==========
 # After the merge, Ethereum offers more block tags than other EVM chains so we separated them out

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1146,6 +1146,85 @@ paths:
               schema:
                 $ref: '#/components/schemas/ownedNFT'
       operationId: sdk-getNftMetadata
+
+  '/{apiKey}/getNftMetadataBatch':
+    get:
+      summary: getNftMetadataBatch
+      description: Gets the metadata for a batch of NFTs.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - name: tokens
+          in: query
+          description: 'An array of objects with the following properties: contractAddress, tokenId, tokenType.'
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/token'
+        - name: options
+          in: query
+          description: 'An object with the following properties: tokenUriTimeoutInMs, refreshCache.'
+          required: false
+          schema:
+            type: object
+            properties:
+              tokenUriTimeoutInMs:
+                type: integer
+                description: The amount of time in milliseconds to wait before timing out when trying to fetch the token URI.
+              refreshCache:
+                type: boolean
+                description: Whether to refresh the cache before returning the metadata.
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // Print NFT metadata returned in the response:
+              alchemy.nft.getNftMetadataBatch(
+                [
+                  {
+                    contractAddress: "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D",
+                    tokenId: "3",
+                    tokenType: "ERC721"
+                  },
+                  {
+                    contractAddress: "0x8a90CAb2b38dba80c64b7734e58Ee1dB38B8992e",
+                    tokenId: "4",
+                    tokenType: "ERC721"
+                  }
+                ],
+                {
+                  tokenUriTimeoutInMs: 5000,
+                  refreshCache: true
+                }
+              ).then(console.log);
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/get_nft_metadata_batch_response'
+      operationId: sdk-getNftMetadataBatch
+
   '/{apiKey}/getContractMetadata':
     get:
       summary: getContractMetadata
@@ -2452,6 +2531,23 @@ components:
         type: string
       required: false
 
+    token:
+      type: object
+      required:
+        - contractAddress
+        - tokenId
+      properties:
+        contractAddress:
+          type: string
+          description: The contract address of the NFT.
+        tokenId:
+          type: string
+          description: The unique identifier of the NFT.
+        tokenType:
+          type: string
+          description: The type of the NFT, such as ERC721.
+          nullable: true
+
     # ===== Response Objects ========
     tokenType_response:
       type: string
@@ -2873,3 +2969,108 @@ components:
         - DROPPED_TRANSACTION
         - ADDRESS_ACTIVITY
         - NFT_ACTIVITY
+
+    get_nft_metadata_batch_response:
+      type: object
+      required:
+        - contract
+        - tokenId
+        - tokenType
+        - title
+        - description
+        - timeLastUpdated
+      properties:
+        contract:
+          type: object
+          required:
+            - address
+            - name
+            - symbol
+            - totalSupply
+            - tokenType
+          properties:
+            address:
+              type: string
+              description: The contract address of the NFT.
+            name:
+              type: string
+              description: The name of the NFT contract.
+            symbol:
+              type: string
+              description: The symbol of the NFT contract.
+            totalSupply:
+              type: string
+              description: The total supply of the NFT contract.
+            tokenType:
+              type: string
+              description: The type of the NFT contract, such as ERC721.
+        tokenId:
+          type: string
+          description: The unique identifier of the NFT.
+        tokenType:
+          type: string
+          description: The type of the NFT, such as ERC721.
+        title:
+          type: string
+          description: The title of the NFT.
+          nullable: true
+        description:
+          type: string
+          description: The description of the NFT.
+          nullable: true
+        timeLastUpdated:
+          type: string
+          format: date-time
+          description: The time when the metadata was last updated.
+        metadataError:
+          type: string
+          description: An error message if there was a problem fetching the metadata.
+          nullable: true
+        rawMetadata:
+          type: object
+          description: The raw metadata of the NFT.
+          nullable: true
+          properties:
+            image:
+              type: string
+              description: The IPFS hash of the image associated with the NFT.
+            attributes:
+              type: array
+              items:
+                type: object
+                required:
+                  - key
+                  - value
+                properties:
+                  key:
+                    type: string
+                    description: The key of the attribute.
+                  value:
+                    type: string
+                    description: The value of the attribute.
+        tokenUri:
+          type: object
+          description: The URI of the NFT.
+          nullable: true
+          properties:
+            raw:
+              type: string
+              description: The raw URI of the NFT.
+            gateway:
+              type: string
+              description: The URI of the NFT accessed through a gateway.
+        media:
+          type: array
+          items:
+            type: object
+            required:
+              - url
+            properties:
+              url:
+                type: string
+                description: The URL of the media.
+                nullable: true
+        spamInfo:
+          type: object
+          description: Information about whether the NFT has been flagged as spam.
+          nullable: true

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1448,6 +1448,96 @@ paths:
               alchemy.nft.searchContractMetadata("hair").then(console.log);
       operationId: sdk-searchContractMetadata
 
+  '/{apiKey}/getNftsForOwnerIterator':
+    get:
+      summary: getNftsForOwnerIterator
+      description: Fetches all NFTs for a given owner and yields them in an async iterable.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - name: owner
+          in: query
+          required: true
+          description: The address of the owner.
+          schema:
+            type: string
+        - name: options
+          in: query
+          required: false
+          description: The optional parameters to use for the request.
+          schema:
+            type: object
+            properties:
+              contractAddresses:
+                type: array
+                items:
+                  type: string
+                  description: Optional list of contract addresses to filter the results by. Limit is 20.
+              excludeFilters:
+                type: array
+                items:
+                  type: object
+                  description: Optional list of filters applied to the query. NFTs that match one or more of these filters are excluded from the response.
+              omitMetadata:
+                type: boolean
+                description: Optional boolean flag to omit NFT metadata. Defaults to false.
+              pageKey:
+                type: string
+                description: A page key returned in a previous response to request the next page of results.
+              pageSize:
+                type: integer
+                description: The number of results to return per page.
+              tokenUriTimeoutInMs:
+                type: integer
+                description: Timeout for the `tokenURI` field in the returned `OwnedNFT` objects.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ownedNFT'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // define the owner address whose NFTs you want to fetch
+              const owner = "0xe5cb067e90d5cd1f8052b83562ae670ba4a211a8";
+
+              // create an async generator function that uses the getNftsForOwnerIterator method
+              async function getNftsForOwner() {
+                try {
+                  // Get the async iterable for the owner's NFTs.
+                  const nftsIterable = alchemy.nft.getNftsForOwnerIterator(owner);
+                  
+                  // Iterate over the NFTs and log them to the console.
+                  for await (const nft of nftsIterable) {
+                    console.log(nft);
+                  }
+                } catch (error) {
+                  console.log(error);
+                }
+              }
+      operationId: sdk-getNftsForOwnerIterator
+
   '/{apiKey}/getContractMetadata':
     get:
       summary: getContractMetadata

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1268,6 +1268,88 @@ paths:
                 description: Indicates whether the metadata was refreshed.
       operationId: sdk-refreshNftMetadata
 
+  /{apiKey}/getNftSales:
+    get:
+      summary: getNftSales
+      description: Gets a list of NFT sales that have happened through on-chain marketplaces.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - name: options
+          in: query
+          schema:
+            type: object
+            properties:
+              buyerAddress:
+                type: string
+                description: The address of the NFT buyer to filter sales by.
+              fromBlock:
+                type: integer
+                description: The block number to start fetching NFT sales data from.
+              limit:
+                type: integer
+                description: The maximum number of NFT sales to return.
+              marketplace:
+                type: string
+                description: The on-chain marketplace to filter sales by.
+              order:
+                type: string
+                description: Whether to return the results in ascending or descending order by block number.
+                enum: [asc, desc]
+              pageKey:
+                type: string
+                description: The pagination key for the next page of results.
+              sellerAddress:
+                type: string
+                description: The address of the NFT seller to filter sales by.
+              taker:
+                type: string
+                description: Whether the buyer or seller was the taker in the sale.
+                enum: [buyer, seller]
+              toBlock:
+                type: integer
+                description: The block number to stop fetching NFT sales data at.
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // Print NFT sales returned in the response:
+              alchemy.nft
+                .getNftSales()
+                .then(console.log);
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pageKey:
+                    type: string
+                    description: The pagination key for the next page of results, if available.
+                  nftSales:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/nftSale'
+      operationId: sdk-getNftSales
+
   '/{apiKey}/getContractMetadata':
     get:
       summary: getContractMetadata
@@ -3118,3 +3200,74 @@ components:
           type: object
           description: Information about whether the NFT has been flagged as spam.
           nullable: true
+
+    nftSale:
+      type: object
+      properties:
+        marketplace:
+          type: string
+          description: The on-chain marketplace where the sale took place.
+        contractAddress:
+          type: string
+          description: The contract address of the NFT.
+        tokenId:
+          type: string
+          description: The token id of the NFT.
+        quantity:
+          type: string
+          description: The quantity of NFTs sold in the sale.
+        buyerAddress:
+          type: string
+          description: The address of the NFT buyer.
+        sellerAddress:
+          type: string
+          description: The address of the NFT seller.
+        taker:
+          type: string
+          description: Whether the buyer or seller was the taker in the sale.
+          enum: [buyer, seller]
+        sellerFee:
+          type: object
+          description: The fee paid by the seller in the sale.
+          properties:
+            amount:
+              type: string
+              description: The amount of the fee.
+            currency:
+              type: string
+              description: The currency of the fee.
+              enum: [eth]
+        marketplaceFee:
+          type: object
+          description: The fee paid to the marketplace in the sale, if applicable.
+          properties:
+            amount:
+              type: string
+              description: The amount of the fee.
+            currency:
+              type: string
+              description: The currency of the fee.
+              enum: [eth]
+        royaltyFee:
+          type: object
+          description: The royalty fee paid in the sale, if applicable.
+          properties:
+            amount:
+              type: string
+              description: The amount of the fee.
+            currency:
+              type: string
+              description: The currency of the fee.
+              enum: [eth]
+        blockNumber:
+          type: integer
+          description: The block number where the sale took place.
+        logIndex:
+          type: integer
+          description: The log index of the sale in the block.
+        bundleIndex:
+          type: integer
+          description: The bundle index of the sale.
+        transactionHash:
+          type: string
+          description: The transaction hash of the sale.

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1268,7 +1268,7 @@ paths:
                 description: Indicates whether the metadata was refreshed.
       operationId: sdk-refreshNftMetadata
 
-  /{apiKey}/getNftSales:
+  '/{apiKey}/getNftSales':
     get:
       summary: getNftSales
       description: Gets a list of NFT sales that have happened through on-chain marketplaces.
@@ -1350,7 +1350,7 @@ paths:
                       $ref: '#/components/schemas/nftSale'
       operationId: sdk-getNftSales
 
-  /{apiKey}/summarizeNftAttributes:
+  '/{apiKey}/summarizeNftAttributes':
     get:
       summary: summarizeNftAttributes
       description: Generate a summary of attribute prevalence for an NFT collection.
@@ -1401,7 +1401,7 @@ paths:
                     $ref: '#/components/schemas/contractAddress'
       operationId: sdk-summarizeNftAttributes
 
-  /{apiKey}/searchContractMetadata:
+  '/{apiKey}/searchContractMetadata':
     get:
       summary: searchContractMetadata
       description: Search for a keyword across metadata of all ERC-721 and ERC-1155 smart contracts.

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1225,6 +1225,49 @@ paths:
                   $ref: '#/components/schemas/get_nft_metadata_batch_response'
       operationId: sdk-getNftMetadataBatch
 
+  '/{apiKey}/refreshNftMetadata':
+    post:
+      summary: refreshNftMetadata
+      description: Refreshes the metadata for a given NFT.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - $ref: '#/components/schemas/contractAddress'
+        - $ref: '#/components/schemas/tokenId'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // Refresh NFT Metadata for a given NFT contract address and token ID.
+              alchemy.nft
+                .refreshNftMetadata("0x06012c8cf97bead5deae237070f9587f8e7a266d", "1")
+                .then(console.log);
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: boolean
+                description: Indicates whether the metadata was refreshed.
+      operationId: sdk-refreshNftMetadata
+
   '/{apiKey}/getContractMetadata':
     get:
       summary: getContractMetadata
@@ -2484,6 +2527,7 @@ components:
       in: query
       schema:
         type: string
+        default: '1'
       required: true
     tokenType:
       name: tokenType

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1525,18 +1525,107 @@ paths:
               // create an async generator function that uses the getNftsForOwnerIterator method
               async function getNftsForOwner() {
                 try {
+                  let nfts = [];
                   // Get the async iterable for the owner's NFTs.
                   const nftsIterable = alchemy.nft.getNftsForOwnerIterator(owner);
                   
-                  // Iterate over the NFTs and log them to the console.
+                  // Iterate over the NFTs and add them to the nfts array.
                   for await (const nft of nftsIterable) {
-                    console.log(nft);
+                    nfts.push(nft);
                   }
+
+                  // Log the NFTs.
+                  console.log(nfts);
                 } catch (error) {
                   console.log(error);
                 }
               }
+
+              // call the async generator function
+              getNftsForOwner();
       operationId: sdk-getNftsForOwnerIterator
+
+  '/{apiKey}/getNftsForContractIterator':
+    get:
+      summary: getNftsForContractIterator
+      description: Fetches all NFTs for a given contract address and yields them in an async iterable.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - $ref: '#/components/schemas/contractAddress'
+        - name: options
+          in: query
+          required: false
+          description: The optional parameters to use for the request.
+          schema:
+            type: object
+            properties:
+              omitMetadata:
+                type: boolean
+                description: Optional boolean flag to omit NFT metadata. Defaults to false.
+              pageKey:
+                type: string
+                description: A page key returned in a previous response to request the next page of results.
+              pageSize:
+                type: integer
+                description: Sets the total number of NFTs to return in the response. Defaults to 100. Maximum page size is 100.
+              tokenUriTimeoutInMs:
+                type: integer
+                description: No set timeout by default - When metadata is requested, this parameter is the timeout (in milliseconds) for the website hosting the metadata to respond. If you want to only access the cache and not live fetch any metadata for cache misses then set this value to 0.
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ownedNFT'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // define the contract address whose NFTs you want to fetch
+              const contractAddress = "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
+
+              // create an async generator function that uses the getNftsForContractIterator method
+              async function getNftsForContract() {
+                try {
+                  let nfts = [];
+                  // Get the async iterable for the contract's NFTs.
+                  alchemy.nft.getNftsForContractIterator(contractAddress);
+                  
+                  // Iterate over the NFTs and add them to the nfts array.
+                  for await (const nft of nftsIterable) {
+                    nfts.push(nft);
+                  }
+
+                  // Log the NFTs.
+                  console.log(nfts);
+                } catch (error) {
+                  console.log(error);
+                }
+              }
+
+              // call the async generator function
+              getNftsForContract();
+      operationId: sdk-getNftsForContractIterator
 
   '/{apiKey}/getContractMetadata':
     get:

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1350,6 +1350,57 @@ paths:
                       $ref: '#/components/schemas/nftSale'
       operationId: sdk-getNftSales
 
+  /{apiKey}/summarizeNftAttributes:
+    get:
+      summary: summarizeNftAttributes
+      description: Generate a summary of attribute prevalence for an NFT collection.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - $ref: '#/components/schemas/contractAddress'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // Get the summary of attribute prevalence for the given NFT collection.
+              alchemy.nft
+                .summarizeNftAttributes("0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D")
+                .then(console.log);
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                description: 'Prevalence counts for each attribute within a collection.'
+                properties:
+                  totalSupply:
+                    type: number
+                    description: 'Total number of NFTs for the input contract.'
+                  summary:
+                    type: object
+                    description: 'Object mapping trait types to the prevalence of each trait within that type.'
+                  contract:
+                    $ref: '#/components/schemas/contractAddress'
+      operationId: sdk-summarizeNftAttributes
+
   '/{apiKey}/getContractMetadata':
     get:
       summary: getContractMetadata
@@ -1852,38 +1903,6 @@ paths:
                 description: 'Boolean representing if the given contract address holds an NFT from the given NFT contract.'
       operationId: sdk-verifyNftOwnership
 
-  # '/{apiKey}/summarizeNftAttributes':
-  #   get:
-  #     summary: summarizeNftAttributes
-  #     description: Generate a summary of attribute prevalence for an NFT collection.
-  #     tags: ['SDK NFT Endpoints']
-  #     parameters:
-  #       - $ref: '#/components/schemas/apiKey'
-  #       - $ref: '#/components/schemas/contractAddress'
-  #     x-readme:
-  #       samples-languages:
-  #         - javascript
-  #         - curl
-  #         - python
-  #         - go
-  #     responses:
-  #       '200':
-  #         description: ''
-  #         content:
-  #           application/json:
-  #             schema:
-  #               type: object
-  #               description: 'Prevalence counts for each attribute within a collection.'
-  #               properties:
-  #                 totalSupply:
-  #                   type: number
-  #                   description: 'Total number of NFTs for the input contract.'
-  #                 summmary:
-  #                   type: object
-  #                   description: 'Object mapping trait types to the prevalence of each trait within that type.'
-  #                 contract:
-  #                   $ref: '#/components/schemas/contractAddress'
-  #     operationId: sdk-summarizeNftAttributes
   # '/{apiKey}/isHolderOfCollection':
   #   get:
   #     summary: isHolderOfCollection

--- a/sdk/sdk.yaml
+++ b/sdk/sdk.yaml
@@ -1401,6 +1401,53 @@ paths:
                     $ref: '#/components/schemas/contractAddress'
       operationId: sdk-summarizeNftAttributes
 
+  /{apiKey}/searchContractMetadata:
+    get:
+      summary: searchContractMetadata
+      description: Search for a keyword across metadata of all ERC-721 and ERC-1155 smart contracts.
+      tags: ['SDK NFT Endpoints']
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - name: query
+          in: query
+          schema:
+            type: string
+            description: The search string that you want to search for in contract metadata.
+          required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                description: An array of object containing information about the NFT contracts whose metadata matches with the given query.
+                items:
+                  $ref: '#/components/schemas/matchedNftContractInfo'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - javascript
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              // Setup: npm install alchemy-sdk
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // Search for "hair" string across metadata of all NFT collections.
+              alchemy.nft.searchContractMetadata("hair").then(console.log);
+      operationId: sdk-searchContractMetadata
+
   '/{apiKey}/getContractMetadata':
     get:
       summary: getContractMetadata
@@ -3290,3 +3337,53 @@ components:
         transactionHash:
           type: string
           description: The transaction hash of the sale.
+
+    matchedNftContractInfo:
+      type: object
+      properties:
+        address:
+          type: string
+          description: Address of the NFT contract.
+        name:
+          type: string
+          description: Name of the NFT contract.
+        symbol:
+          type: string
+          description: Symbol of the NFT contract.
+        totalSupply:
+          type: string
+          description: Total supply of NFTs for the contract.
+        tokenType:
+          type: string
+          description: Type of the NFT contract, either "ERC721" or "ERC1155".
+        openSea:
+          type: object
+          description: OpenSea metadata for the NFT contract.
+          properties:
+            floorPrice:
+              type: number
+              description: Minimum price for an NFT to be sold on OpenSea.
+            collectionName:
+              type: string
+              description: Name of the collection on OpenSea.
+            safelistRequestStatus:
+              type: string
+              description: Current status of the contract's safelist request on OpenSea.
+            imageUrl:
+              type: string
+              description: URL of the main image for the NFT contract.
+            description:
+              type: string
+              description: Description of the NFT contract.
+            externalUrl:
+              type: string
+              description: External URL of the NFT contract.
+            twitterUsername:
+              type: string
+              description: Twitter username for the NFT contract.
+            discordUrl:
+              type: string
+              description: URL for the NFT contract's Discord server.
+            lastIngestedAt:
+              type: string
+              description: Timestamp of the last time the contract's metadata was updated on OpenSea.


### PR DESCRIPTION
This PR was created as part of [this task](https://app.asana.com/0/1203348300619757/1203583254023819)

A total of 7 new methods were added in this PR:

- `getNftMetadataBatch`
- `refreshNftMetadata`
- `getNftSales`
- `summarizeNftAttributes`
- `searchContractMetadata`
- `getNftsForOwnerIterator`
- `getNftsForContractIterator`

You can test all these methods in the [sample project](https://alchemy-api-docs.readme.io/reference/sdk-refreshnftmetadata) before merging the PR.