### PR TITLE
fixed the request body and disabled explorer for all the debug APIs

### DIFF
--- a/debug/debug_traceBlockByHash.yaml
+++ b/debug/debug_traceBlockByHash.yaml
@@ -23,6 +23,8 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/debug_traceBlockByHash
+      x-readme:
+        explorer-enabled: false
       responses:
         '200':
           description: 'Returns - array of block traces'

--- a/debug/debug_traceBlockByNumber.yaml
+++ b/debug/debug_traceBlockByNumber.yaml
@@ -18,6 +18,8 @@ paths:
             default: docs-demo
             description: For higher throughput, **[create your own API key](https://alchemy.com/?a=docs-demo)**
           required: true
+      x-readme:
+        explorer-enabled: false
       requestBody:
         content:
           application/json:

--- a/debug/debug_traceCall.yaml
+++ b/debug/debug_traceCall.yaml
@@ -23,6 +23,8 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/debug_traceCall
+      x-readme:
+        explorer-enabled: false
       responses:
         '200':
           description: 'Returns - Array of block traces'

--- a/debug/debug_traceTransaction.yaml
+++ b/debug/debug_traceTransaction.yaml
@@ -23,6 +23,8 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/debug_traceTransaction
+      x-readme:
+        explorer-enabled: false
       responses:
         '200':
           description: 'Returns - transaction trace'

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1195,8 +1195,8 @@ debug_traceCall:
             - debug_traceCall
         params:
           type: array
-          minItems: 3
-          maxItems: 3
+          minItems: 1
+          maxItems: 1
           description: |
             1. `object` - Transaction Object
             2. `string` - Block Identifier: Block hash, block number (in hex), or block tag
@@ -1241,8 +1241,8 @@ debug_traceBlockByHash:
           description: |
             1. `string` - Block hash for the block to be traced
             2. `tracer` Object - Currently supports `callTracer` and `prestateTracer` (see above for definitions).
-          minItems: 2
-          maxItems: 2
+          minItems: 1
+          maxItems: 1
           items:
             anyOf:
               - type: string
@@ -1271,8 +1271,8 @@ debug_traceBlockByNumber:
           description: |
             1. String - Block number (in hex) or block tag
             2. `tracer` Object - Currently supports `callTracer` and `prestateTracer` (see above for definitions).
-          minItems: 2
-          maxItems: 2
+          minItems: 1
+          maxItems: 1
           items:
             anyOf:
               - $ref: '#/blockNumber_or_blocktag_param_eth'
@@ -1296,8 +1296,8 @@ debug_traceTransaction:
             - debug_traceTransaction
         params:
           type: array
-          minItems: 2
-          maxItems: 2
+          minItems: 1
+          maxItems: 1
           description: |
             1. String - Transaction hash
             2. Object - options for call, can be any of the following options:


### PR DESCRIPTION
In the PR, I have done two things: 

## 1. Fixed the request bodies for all the debug APIs, earlier all of them had an array of params in the request body, even though they should have one. 

For example, this was the case before (for all the debug APIs): 

![image](https://user-images.githubusercontent.com/83442423/210541634-bd0dec36-7eba-4a74-acfa-2742a78a8500.png)

And this is the case now (for all the debug APIs):

![image](https://user-images.githubusercontent.com/83442423/210541737-bcd343b6-4e9a-40bc-b99a-cee764a49556.png)


## 2. Disabled the explorer (the "try it" button) for all the debug APIs, since they do not work, due to the workaround that we are doing to define multi-type arrays.




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203591397364454