### PR TITLE
added blockHash option to JSON-RPC methods that currently support def…

### DIFF
--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -170,17 +170,15 @@ eth_getBlockTransactionCountByNumber:
 eth_getTransactionCount:
   allOf:
     - $ref: '#/common_request_fields'
+    - $ref: '#/address_and_blockNumberOrTagOrHash_param_EIP1898'
     - type: object
       properties:
-        address:
-          $ref: '#/AddressParam'
-        blockNumberOrTagOrHash:
-          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getTransactionCount
           enum:
             - eth_getTransactionCount
+
 eth_getTransactionByBlockHashAndIndex:
   allOf:
     - $ref: '#/common_request_fields'
@@ -287,15 +285,13 @@ eth_cancelPrivateTransaction:
               txHash:
                 type: string
                 description: Transaction hash for private transaction to be cancelled.
+
 eth_getBalance:
   allOf:
     - $ref: '#/common_request_fields'
+    - $ref: '#/address_and_blockNumberOrTagOrHash_param_EIP1898'
     - type: object
       properties:
-        address:
-          $ref: '#/AddressParam'
-        blockNumberOrTagOrHash:
-          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getBalance
@@ -312,27 +308,36 @@ eth_getStorageAt:
           default: eth_getStorageAt
           enum:
             - eth_getStorageAt
-        address:
-          $ref: '#/AddressParam'
-        position:
-          type: string
-          description: Integer of the slot position in the storage (in hex)
-        blockNumberOrTagOrHash:
-          $ref: '#/BlockNumberOrTagOrHash'
+        params:
+          type: array
+          description: |
+            1. String - 20 Bytes - address of the storage
+            2. String - Integer of the slot position in the storage (in hex)
+            3. String - Either the hex value of a **block number** OR a **block hash** OR One of the following **block tags**:
+              * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
+              * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
+              * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
+              * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
+              * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
+          minItems: 3
+          maxItems: 3
+          items:
+            type: string
+          default:
+            ['0x407d73d8a49eeb85d32cf465507dd71d507100c1', '0x0', 'latest']
+
 eth_getCode:
   allOf:
     - $ref: '#/common_request_fields'
+    - $ref: '#/address_and_blockNumberOrTagOrHash_param_EIP1898'
     - type: object
       properties:
-        address:
-          $ref: '#/AddressParam'
-        blockNumberOrTagOrHash:
-          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getCode
           enum:
             - eth_getCode
+
 eth_accounts:
   allOf:
     - $ref: '#/common_request_fields'
@@ -348,20 +353,34 @@ eth_getProof:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
-        address:
-          $ref: '#/AddressParam'
-        storageKeys:
-          type: array
-          description: array of storage-keys which should be proofed and included
-          items:
-            type: string
-        blockNumberOrTagOrHash:
-          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getProof
           enum:
             - eth_getProof
+        params:
+          description: |
+            1. String - 20 Bytes - Address of the account
+            2. Array - 32 Bytes - array of storage-keys which should be proofed and included
+            3. String - Either the hex value of a **block number** OR One of the following **block tags**:
+              * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
+              * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
+              * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
+              * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
+              * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            anyOf:
+              - $ref: '#/AddressParam'
+              - type: array
+                title: Array of storage keys
+                description: array of storage-keys which should be proofed and included
+                items:
+                  type: string
+              - $ref: '#/BlockNumberOrTagOrHash'
+                title: Block Number or Block Hash or Block Tag
 
 eth_protocolVersion:
   allOf:
@@ -1566,6 +1585,23 @@ address_and_blockNumber_param_eth:
       maxItems: 2
       items:
         type: string
+
+address_and_blockNumberOrTagOrHash_param_EIP1898:
+  type: object
+  properties:
+    params:
+      type: array
+      description: |
+        1. String - 20 Bytes - Address
+        2. String - Either the hex value of a **block number** OR a **block hash** OR One of the following **block tags**:
+            * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
+            * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
+            * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
+      minItems: 2
+      maxItems: 2
+      items:
+        type: string
+      default: ['0xe5cB067E90D5Cd1F8052B83562Ae670bA4A211a8', 'latest']
 
 BlockNumberOrTagOrHash:
   title: Block number or tag, or block hash

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -170,9 +170,14 @@ eth_getBlockTransactionCountByNumber:
 eth_getTransactionCount:
   allOf:
     - $ref: '#/common_request_fields'
-    - $ref: '#/address_and_blockNumber_param_eth'
     - type: object
       properties:
+        address:
+          type: string
+          description: 20 Bytes - Address
+          pattern: '^0[xX][0-9a-fA-F]{40}$'
+        blockNumberOrTagOrHash:
+          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getTransactionCount
@@ -287,14 +292,20 @@ eth_cancelPrivateTransaction:
 eth_getBalance:
   allOf:
     - $ref: '#/common_request_fields'
-    - $ref: '#/address_and_blockNumber_param_eth'
     - type: object
       properties:
+        address:
+          type: string
+          description: 20 Bytes - Address
+          pattern: '^0[xX][0-9a-fA-F]{40}$'
+        blockNumberOrTagOrHash:
+          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getBalance
           enum:
             - eth_getBalance
+
 eth_getStorageAt:
   allOf:
     - $ref: '#/common_request_fields'
@@ -305,27 +316,26 @@ eth_getStorageAt:
           default: eth_getStorageAt
           enum:
             - eth_getStorageAt
-        params:
-          type: array
-          description: |
-            1. String - 20 Bytes - address of the storage
-            2. String - Integer of the slot position in the storage (in hex)
-            3. String - Either the hex value of a **block number** OR One of the following **block tags**:
-              * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
-              * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
-              * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
-              * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
-              * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
-          minItems: 3
-          maxItems: 3
-          items:
-            type: string
+        address:
+          type: string
+          description: 20 Bytes - Address of the storage
+          pattern: '^0[xX][0-9a-fA-F]{40}$'
+        position:
+          type: string
+          description: Integer of the slot position in the storage (in hex)
+        blockNumberOrTagOrHash:
+          $ref: '#/BlockNumberOrTagOrHash'
 eth_getCode:
   allOf:
     - $ref: '#/common_request_fields'
-    - $ref: '#/address_and_blockNumber_param_eth'
     - type: object
       properties:
+        address:
+          type: string
+          description: 20 Bytes - Address
+          pattern: '^0[xX][0-9a-fA-F]{40}$'
+        blockNumberOrTagOrHash:
+          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getCode
@@ -346,36 +356,23 @@ eth_getProof:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
+        address:
+          type: string
+          description: 20 Bytes - Address of the account
+          pattern: '^0[xX][0-9a-fA-F]{40}$'
+        storageKeys:
+          type: array
+          description: array of storage-keys which should be proofed and included
+          items:
+            type: string
+        blockNumberOrTagOrHash:
+          $ref: '#/BlockNumberOrTagOrHash'
         method:
           type: string
           default: eth_getProof
           enum:
             - eth_getProof
-        params:
-          description: |
-            1. String - 20 Bytes - Address of the account
-            2. Array - 32 Bytes - array of storage-keys which should be proofed and included
-            3. String - Either the hex value of a **block number** OR One of the following **block tags**:
-              * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
-              * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
-              * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
-              * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Mainnet and Goerli**.
-              * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
-          type: array
-          minItems: 3
-          maxItems: 3
-          items:
-            anyOf:
-              - type: string
-                title: Address
-                description: Address of the account
-              - type: array
-                title: Array of storage keys
-                description: array of storage-keys which should be proofed and included
-                items:
-                  type: string
-              - $ref: '#/blockNumber_or_blocktag_param_eth'
-                title: Block Number or Block Tag
+
 eth_protocolVersion:
   allOf:
     - $ref: '#/common_request_fields'
@@ -1356,6 +1353,7 @@ topics:
   description: Array of 32 Bytes DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options.
   items:
     type: string
+
 eth_call_550_gas:
   allOf:
     - $ref: '#/common_request_fields'
@@ -1376,8 +1374,8 @@ eth_call_550_gas:
                   - $ref: '#/transaction_object'
                     title: Transaction Object
                   - $ref: '#/gas_550'
-              - $ref: '#/blockNumber_or_blocktag_param_eth'
-                title: Block number or block tag
+              - $ref: '#/BlockNumberOrTagOrHash'
+                title: Block number or block tag or block hash
 
 transaction_object:
   type: object
@@ -1578,6 +1576,50 @@ address_and_blockNumber_param_eth:
       maxItems: 2
       items:
         type: string
+
+BlockNumberOrTagOrHash:
+  title: Block number or tag, or block hash
+  oneOf:
+    - title: Block Number
+      $ref: '#/BlockNumber'
+    - title: Block Tag
+      $ref: '#/BlockTag'
+    - title: Block Hash
+      $ref: '#/BlockHash'
+
+BlockTag:
+  title: Block tag
+  type: string
+  description: |
+    One of the following **block tags**:
+      * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
+      * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
+      * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
+  enum:
+    - pending
+    - latest
+    - earliest
+  default: latest
+
+BlockNumber:
+  title: Block number
+  type: string
+  description: The hex value of a **block number**.
+
+BlockHash:
+  title: Block hash
+  type: object
+  required:
+    - blockHash
+  properties:
+    blockHash:
+      title: Block hash
+      type: string
+    requireCanonical:
+      title: Require canonical
+      type: boolean
+      default: false
+
 address_and_blockNumber_param_l2:
   type: object
   properties:

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -173,9 +173,7 @@ eth_getTransactionCount:
     - type: object
       properties:
         address:
-          type: string
-          description: 20 Bytes - Address
-          pattern: '^0[xX][0-9a-fA-F]{40}$'
+          $ref: '#/AddressParam'
         blockNumberOrTagOrHash:
           $ref: '#/BlockNumberOrTagOrHash'
         method:
@@ -295,9 +293,7 @@ eth_getBalance:
     - type: object
       properties:
         address:
-          type: string
-          description: 20 Bytes - Address
-          pattern: '^0[xX][0-9a-fA-F]{40}$'
+          $ref: '#/AddressParam'
         blockNumberOrTagOrHash:
           $ref: '#/BlockNumberOrTagOrHash'
         method:
@@ -317,9 +313,7 @@ eth_getStorageAt:
           enum:
             - eth_getStorageAt
         address:
-          type: string
-          description: 20 Bytes - Address of the storage
-          pattern: '^0[xX][0-9a-fA-F]{40}$'
+          $ref: '#/AddressParam'
         position:
           type: string
           description: Integer of the slot position in the storage (in hex)
@@ -331,9 +325,7 @@ eth_getCode:
     - type: object
       properties:
         address:
-          type: string
-          description: 20 Bytes - Address
-          pattern: '^0[xX][0-9a-fA-F]{40}$'
+          $ref: '#/AddressParam'
         blockNumberOrTagOrHash:
           $ref: '#/BlockNumberOrTagOrHash'
         method:
@@ -357,9 +349,7 @@ eth_getProof:
     - type: object
       properties:
         address:
-          type: string
-          description: 20 Bytes - Address of the account
-          pattern: '^0[xX][0-9a-fA-F]{40}$'
+          $ref: '#/AddressParam'
         storageKeys:
           type: array
           description: array of storage-keys which should be proofed and included
@@ -1585,7 +1575,14 @@ BlockNumberOrTagOrHash:
     - title: Block Tag
       $ref: '#/BlockTag'
     - title: Block Hash
-      $ref: '#/BlockHash'
+      $ref: '#/BlockHashEIP1898'
+
+AddressParam:
+  title: Address
+  type: string
+  description: 20 Bytes - Address
+  pattern: '^0[xX][0-9a-fA-F]{40}$'
+  default: '0xe5cB067E90D5Cd1F8052B83562Ae670bA4A211a8'
 
 BlockTag:
   title: Block tag
@@ -1605,16 +1602,16 @@ BlockNumber:
   title: Block number
   type: string
   description: The hex value of a **block number**.
+  default: '0x61A80'
 
-BlockHash:
+BlockHashEIP1898:
   title: Block hash
   type: object
   required:
     - blockHash
   properties:
     blockHash:
-      title: Block hash
-      type: string
+      $ref: '#/blockHash_param'
     requireCanonical:
       title: Require canonical
       type: boolean


### PR DESCRIPTION
In addition to adding `blockHash` option to the required methods, I have actually improved the request bodies of these methods.

To demonstrate what I mean, please compare the request bodies of any of the methods affected with the existing request bodies, for example: 

Check [eth_getProof](https://docs.alchemy.com/reference/eth-getproof-arbitrum) before this PR and [eth_getProof](https://alchemy-api-docs.readme.io/reference/eth-getproof) after this PR.

Here is what all the affected methods will look like after merging this PR: 

- [eth_getBalance](https://alchemy-api-docs.readme.io/reference/eth-getbalance)
- [eth_getStorageAt](https://alchemy-api-docs.readme.io/reference/eth-getstorageat)
- [eth_getTransactionCount](https://alchemy-api-docs.readme.io/reference/eth-gettransactioncount)
- [eth_getCode](https://alchemy-api-docs.readme.io/reference/eth-getcode)
- [eth_call](https://alchemy-api-docs.readme.io/reference/eth-call-1)
- [eth_getProof](https://alchemy-api-docs.readme.io/reference/eth-getproof)

This will change the request bodies of all these methods on all the networks.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203768674197223