### PR TITLE
Fixed wrong server url for NFT API endpoints and added all the networks in NFT API endpoints

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -9,6 +9,12 @@ servers:
         enum:
           - eth-mainnet
           - eth-goerli
+          - polygon-mainnet
+          - polygon-mumbai
+          - arb-mainnet
+          - arb-goerli
+          - opt-mainnet
+          - opt-goerli
         default: eth-mainnet
 paths:
   '/{apiKey}/getNFTs':

--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -3,7 +3,7 @@ info:
   title: 🎨 NFT API
   version: '1.0'
 servers:
-  - url: https://{network}.g.alchemy.com/v2
+  - url: https://{network}.g.alchemy.com/nft/v2
     variables:
       network:
         enum:


### PR DESCRIPTION
Fixed the wrong server url in NFT API (didn't have `/nft/` before) and added all the networks in NFT API endpoints because different endpoints are available on different networks.

This is how the network selector will look like for NFT API endpoints after merging this PR: 

![image](https://user-images.githubusercontent.com/83442423/217053552-c5d3af1f-8aa8-4282-b9c2-be3b0df647e3.png)

You can also check it live here: https://alchemy-api-docs.readme.io/reference/getnfts-2