### PR TITLE
fixed the failed request issue with getNfts while adding filters

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -1019,7 +1019,7 @@ paths:
                 withoutMetadata:
                   $ref: '#/components/schemas/withoutMetadataGetContractsForOwner_response'
                 withMetadata:
-                  $ref: '#/components/schemas/withMetadataGetContractsForOwner_response'                  
+                  $ref: '#/components/schemas/withMetadataGetContractsForOwner_response'
       operationId: getContractsForOwner
   '/{apiKey}/reportSpam':
     get:
@@ -1119,6 +1119,7 @@ components:
           enum:
             - SPAM
             - AIRDROPS
+          default: [SPAM]
       in: query
     address:
       name: address
@@ -1141,6 +1142,7 @@ components:
           enum:
             - SPAM
             - AIRDROPS
+          default: [SPAM]
       in: query
     contractAddress:
       name: contractAddress
@@ -1716,7 +1718,7 @@ components:
           ],
           "totalCount": 2120,
           "pageKey": "03949322-9b2c-4fdd-aab6-1369e29fa5b2"
-        }     
+        }
     withContractFiltering_response:
       summary: 'Response (with contract filtering)'
       value: >


### PR DESCRIPTION
The PR is related to this task: https://app.asana.com/0/1201986929510411/1203848874600130

The issue was arising because no default was set on `includeFilters` and `excludeFilters` but now it's working perfectly fine, you can see the live page here: 

https://alchemy-api-docs.readme.io/reference/getnfts-3

This is how the method will work after merging the PR 

(NOTE: You need to change the API key while making request with the API from the above link in my demo project as `docs-demo` won't work in this case).