### PR TITLE
added an example response to eth_sendPrivateTransaction

### DIFF
--- a/evm_examples.yaml
+++ b/evm_examples.yaml
@@ -2441,3 +2441,10 @@ alchemy_getAssetTransfers:
           ],
       },
   }
+
+string_result_response:
+  {
+    'jsonrpc': '2.0',
+    'id': 1,
+    'result': '0xb1770efb14906e509893b6190359658208ae64d0c56e22f748a1b0869885559e',
+  }

--- a/evm_responses.yaml
+++ b/evm_responses.yaml
@@ -341,7 +341,8 @@ string_result_response:
       properties:
         result:
           type: string
-          example: '0x'
+      example:
+        $ref: ./evm_examples.yaml#/string_result_response
 getTxn_result_response:
   allOf:
     - $ref: '#/common_response_fields'

--- a/evm_responses.yaml
+++ b/evm_responses.yaml
@@ -341,6 +341,7 @@ string_result_response:
       properties:
         result:
           type: string
+          description: '32 Bytes String - The Transaction Hash.'
       example:
         $ref: ./evm_examples.yaml#/string_result_response
 getTxn_result_response:

--- a/transact/eth_sendPrivateTransaction.yaml
+++ b/transact/eth_sendPrivateTransaction.yaml
@@ -72,7 +72,7 @@ paths:
               main();
       responses:
         '200':
-          description: ''
+          description: 'Returns 32 Bytes String - The Transaction Hash.'
           content:
             application/json:
               schema:


### PR DESCRIPTION
[`eth_sendPrivateTransaction`](https://alchemy-api-docs.readme.io/reference/eth-sendprivatetransaction-5) did not have an example response before which I have added now, as you can see in the image below: 

![image](https://user-images.githubusercontent.com/83442423/219699613-5ee2ea89-1683-4362-948a-ffa59fcfdd77.png)

Also added a description for the response, as you can see in the image below: 

![image](https://user-images.githubusercontent.com/83442423/220149447-a8858d09-330c-46f2-b044-81b1b4e4dbf4.png)


You can also test it live here: 

https://alchemy-api-docs.readme.io/reference/eth-sendprivatetransaction-6