### PR TITLE
Added `requestAirdrop` endpoint to Solana APIs

### DIFF
--- a/Solana/requestAirdrop.yaml
+++ b/Solana/requestAirdrop.yaml
@@ -53,4 +53,4 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/requestAirdrop
-      operationId: getVoteAccounts
+      operationId: requestAirdrop

--- a/Solana/requestAirdrop.yaml
+++ b/Solana/requestAirdrop.yaml
@@ -1,0 +1,56 @@
+openapi: 3.1.0
+info:
+  title: Request Airdrop
+  version: '1.0'
+servers:
+  - url: 'https://solana-mainnet.g.alchemy.com/v2'
+paths:
+  /{apiKey}:
+    post:
+      summary: requestAirdrop
+      description: Requests an airdrop of lamports to a Pubkey
+      tags: []
+      parameters:
+        - name: apiKey
+          in: path
+          schema:
+            type: string
+            default: docs-demo
+            description: |
+              <style>
+                .custom-style {
+                  color: #048FF4;
+                }
+              </style>
+              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: solana_body.yaml#/requestAirdrop
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+        code-samples:
+          - language: shell
+            name: cURL
+            code: |
+              curl https://solana-mainnet.g.alchemy.com/v2/YOUR-API-KEY -X POST -H "Content-Type: application/json" -d '
+              {
+                "jsonrpc": "2.0", "id": 1,
+                "method": "requestAirdrop",
+                "params": [
+                  "83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",
+                  1000000000
+                ]
+              }'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: solana_responses.yaml#/requestAirdrop
+      operationId: getVoteAccounts

--- a/Solana/solana_body.yaml
+++ b/Solana/solana_body.yaml
@@ -867,6 +867,33 @@ getTransaction:
                     type: number
                     description: 'Set the max transaction version to return in responses. If the requested transaction is a higher version, an error will be returned.'
 
+requestAirdrop:
+  allOf:
+    - $ref: '#/common_request_fields'
+    - type: object
+      properties:
+        method:
+          type: string
+          default: requestAirdrop
+          enum:
+            - requestAirdrop
+        params:
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            oneOf:
+              - type: string
+                description: Pubkey of account to receive lamports, as a base-58 encoded string
+                default: '83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri'
+              - type: number
+                description: Lamports to airdrop, as a "u64"
+                default: 1000000000
+              - type: object
+                properties:
+                  commitment:
+                    $ref: '#/commitment'
+
 # ============= Solana API Models ===============
 common_request_fields:
   type: object

--- a/Solana/solana_responses.yaml
+++ b/Solana/solana_responses.yaml
@@ -959,3 +959,13 @@ getTransaction:
               type: number
               nullable: true
               description: Transaction version. Undefined if maxSupportedTransactionVersion is not set in request params.
+
+requestAirdrop:
+  allOf:
+    - $ref: '#/common_response_fields'
+    - type: object
+      properties:
+        result:
+          type: string
+          description: Transaction Signature of the airdrop, as a base-58 encoded string
+          example: 5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW


### PR DESCRIPTION
Added the [`requestAirdrop`](https://docs.solana.com/api/http#requestairdrop) endpoint to Solana APIs.

You can also [test it live here](https://alchemy-api-docs.readme.io/reference/getvoteaccounts-1) before merging the PR

[Test Live ↗️](https://alchemy-api-docs.readme.io/reference/getvoteaccounts-1)

I've also attached a screenshot below:
![image](https://user-images.githubusercontent.com/83442423/220761125-96ec3d43-14df-4773-87ea-dc0c15cae7ac.png)