### PR TITLE
updated API references to remove id and jsonrpc fields from view

### DIFF
--- a/Solana/solana_body.yaml
+++ b/Solana/solana_body.yaml
@@ -5,10 +5,8 @@ getBlockHeight:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlockHeight
-          enum:
-            - getBlockHeight
         params:
           type: array
           items:
@@ -23,10 +21,8 @@ getBlock:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlock
-          enum:
-            - getBlock
         params:
           type: array
           items:
@@ -63,10 +59,8 @@ getBlocks:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlocks
-          enum:
-            - getBlocks
         params:
           type: array
           items:
@@ -86,10 +80,8 @@ getBlocksWithLimit:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlocksWithLimit
-          enum:
-            - getBlocksWithLimit
         params:
           type: array
           items:
@@ -100,10 +92,8 @@ getBlockTime:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlockTime
-          enum:
-            - getBlockTime
         params:
           type: array
           minItems: 1
@@ -116,10 +106,8 @@ getBlockCommitment:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlockCommitment
-          enum:
-            - getBlockCommitment
         params:
           type: array
           minItems: 1
@@ -132,10 +120,8 @@ getBlockProduction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBlockProduction
-          enum:
-            - getBlockProduction
         params:
           type: array
           items:
@@ -168,10 +154,8 @@ isBlockhashValid:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: isBlockhashValid
-          enum:
-            - isBlockhashValid
         params:
           type: array
           minItems: 2
@@ -187,10 +171,8 @@ getAccountInfo:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getAccountInfo
-          enum:
-            - getAccountInfo
         params:
           type: array
           minItems: 2
@@ -212,10 +194,8 @@ getBalance:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getBalance
-          enum:
-            - getBalance
         params:
           type: array
           items:
@@ -229,10 +209,8 @@ getMultipleAccounts:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getMultipleAccounts
-          enum:
-            - getMultipleAccounts
         params:
           type: array
           minItems: 2
@@ -258,10 +236,8 @@ getProgramAccounts:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getProgramAccounts
-          enum:
-            - getProgramAccounts
         params:
           type: array
           items:
@@ -287,10 +263,8 @@ getVoteAccounts:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getVoteAccounts
-          enum:
-            - getVoteAccounts
         params:
           type: array
           items:
@@ -315,10 +289,8 @@ getLargestAccounts:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getLargestAccounts
-          enum:
-            - getLargestAccounts
         params:
           type: array
           items:
@@ -339,30 +311,24 @@ getClusterNodes:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getClusterNodes
-          enum:
-            - getClusterNodes
 getVersion:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getVersion
-          enum:
-            - getVersion
 getEpochInfo:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getVersion
-          enum:
-            - getVersion
         params:
           type: array
           items:
@@ -373,20 +339,16 @@ getEpochSchedule:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getEpochSchedule
-          enum:
-            - getEpochSchedule
 getFeeForMessage:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getFeeForMessage
-          enum:
-            - getFeeForMessage
         params:
           type: array
           description: |
@@ -402,40 +364,32 @@ getFirstAvailableBlock:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getFirstAvailableBlock
-          enum:
-            - getFirstAvailableBlock
 getGenesisHash:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getGenesisHash
-          enum:
-            - getGenesisHash
 getHighestSnapshotSlot:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getHighestSnapshotSlot
-          enum:
-            - getHighestSnapshotSlot
 getMinimumBalanceForRentExemption:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getMinimumBalanceForRentExemption
-          enum:
-            - getMinimumBalanceForRentExemption
         params:
           type: array
           items:
@@ -452,10 +406,8 @@ getRecentPerformanceSamples:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getRecentPerformanceSamples
-          enum:
-            - getRecentPerformanceSamples
         params:
           type: array
           description: Array of number of samples to return (maximum 720).
@@ -469,30 +421,24 @@ getHealth:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getHealth
-          enum:
-            - getHealth
 getIdentity:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getIdentity
-          enum:
-            - getIdentity
 getInflationGovernor:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getInflationGovernor
-          enum:
-            - getInflationGovernor
         params:
           type: array
           items:
@@ -506,20 +452,16 @@ getInflationRate:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getInflationRate
-          enum:
-            - getInflationRate
 getInflationReward:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getInflationReward
-          enum:
-            - getInflationReward
         params:
           type: array
           items:
@@ -544,10 +486,8 @@ getSupply:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getSupply
-          enum:
-            - getSupply
         params:
           type: array
           items:
@@ -565,10 +505,8 @@ getSlot:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getSlot
-          enum:
-            - getSlot
         params:
           type: array
           items:
@@ -579,10 +517,8 @@ getSlotLeaders:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getSlotLeaders
-          enum:
-            - getSlotLeaders
         params:
           type: array
           default: [165768577, 5]
@@ -597,40 +533,32 @@ getMaxRetransmitSlot:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getMaxRetransmitSlot
-          enum:
-            - getMaxRetransmitSlot
 getMaxShredInsertSlot:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getMaxShredInsertSlot
-          enum:
-            - getMaxShredInsertSlot
 minimumLedgerSlot:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: minimumLedgerSlot
-          enum:
-            - minimumLedgerSlot
 getTokenAccountBalance:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getTokenAccountBalance
-          enum:
-            - getTokenAccountBalance
         params:
           type: array
           items:
@@ -647,10 +575,8 @@ getTokenAccountsByOwner:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getTokenAccountsByOwner
-          enum:
-            - getTokenAccountsByOwner
         params:
           type: array
           items:
@@ -683,10 +609,8 @@ getTokenSupply:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getTokenSupply
-          enum:
-            - getTokenSupply
         params:
           type: array
           items:
@@ -703,10 +627,8 @@ getSignaturesForAddress:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getSignaturesForAddress
-          enum:
-            - getSignaturesForAddress
         params:
           type: array
           items:
@@ -735,10 +657,8 @@ getSignatureStatuses:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getSignatureStatuses
-          enum:
-            - getSignatureStatuses
         params:
           type: array
           minItems: 2
@@ -758,10 +678,8 @@ sendTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: sendTransaction
-          enum:
-            - sendTransaction
         params:
           type: array
           minItems: 2
@@ -792,10 +710,8 @@ simulateTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: simulateTransaction
-          enum:
-            - simulateTransaction
         params:
           type: array
           minItems: 2
@@ -845,10 +761,8 @@ getTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: getTransaction
-          enum:
-            - getTransaction
         params:
           type: array
           minItems: 2
@@ -873,10 +787,8 @@ requestAirdrop:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ../components/schemas.yaml#/Method
           default: requestAirdrop
-          enum:
-            - requestAirdrop
         params:
           type: array
           minItems: 1

--- a/Solana/solana_body.yaml
+++ b/Solana/solana_body.yaml
@@ -899,11 +899,9 @@ common_request_fields:
   type: object
   properties:
     id:
-      type: integer
-      default: 1
+      $ref: ../components/schemas.yaml#/Id
     jsonrpc:
-      type: string
-      default: '2.0'
+      $ref: ../components/schemas.yaml#/JsonRpc
 encoding:
   type: string
   description: |

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1356,11 +1356,9 @@ common_request_fields:
   type: object
   properties:
     id:
-      type: integer
-      default: 1
+      $ref: ./components/schemas.yaml#/Id
     jsonrpc:
-      type: string
-      default: '2.0'
+      $ref: ./components/schemas.yaml#/JsonRpc
 filter_options:
   type: object
   properties:

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -5,20 +5,16 @@ eth_blockNumber:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_blockNumber
-          enum:
-            - eth_blockNumber
 eth_getBlockByHash:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBlockByHash
-          enum:
-            - eth_getBlockByHash
         params:
           type: array
           description: |
@@ -38,10 +34,8 @@ eth_getBlockByNumber:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBlockByNumber
-          enum:
-            - eth_getBlockByNumber
         params:
           type: array
           description: |
@@ -67,10 +61,8 @@ eth_getBlockByNumber_l2:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBlockByNumber
-          enum:
-            - eth_getBlockByNumber
         params:
           type: array
           description: |
@@ -90,10 +82,8 @@ eth_getLogs:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getLogs
-          enum:
-            - eth_getLogs
         params:
           type: array
           minItems: 1
@@ -107,10 +97,8 @@ eth_getTransactionByHash:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getTransactionByHash
-          enum:
-            - eth_getTransactionByHash
 eth_getTransactionReceipt:
   allOf:
     - $ref: '#/common_request_fields'
@@ -118,20 +106,16 @@ eth_getTransactionReceipt:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getTransactionReceipt
-          enum:
-            - eth_getTransactionReceipt
 eth_getBlockTransactionCountByHash:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBlockTransactionCountByHash
-          enum:
-            - eth_getBlockTransactionCountByHash
         params:
           type: array
           minItems: 1
@@ -144,10 +128,8 @@ eth_getBlockTransactionCountByNumber:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBlockTransactionCountByNumber
-          enum:
-            - eth_getBlockTransactionCountByNumber
         params:
           type: array
           description: |
@@ -175,10 +157,8 @@ eth_getTransactionCount:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getTransactionCount
-          enum:
-            - eth_getTransactionCount
 
 eth_getTransactionByBlockHashAndIndex:
   allOf:
@@ -187,10 +167,9 @@ eth_getTransactionByBlockHashAndIndex:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getTransactionByBlockHashAndIndex
-          enum:
-            - eth_getTransactionByBlockHashAndIndex
+
 eth_getTransactionByBlockNumberAndIndex:
   allOf:
     - $ref: '#/common_request_fields'
@@ -198,20 +177,17 @@ eth_getTransactionByBlockNumberAndIndex:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getTransactionByBlockNumberAndIndex
-          enum:
-            - eth_getTransactionByBlockNumberAndIndex
+
 eth_getBlockReceipts:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBlockReceipts
-          enum:
-            - eth_getBlockReceipts
         params:
           $ref: '#/blockNumber_or_blockHash_param_eth'
 
@@ -222,10 +198,8 @@ eth_sendRawTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_sendRawTransaction
-          enum:
-            - eth_sendRawTransaction
 alchemy_getGasOptimizedTransactionStatus:
   allOf:
     - $ref: '#/common_request_fields'
@@ -233,20 +207,16 @@ alchemy_getGasOptimizedTransactionStatus:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: alchemy_getGasOptimizedTransactionStatus
-          enum:
-            - alchemy_getGasOptimizedTransactionStatus
 eth_sendPrivateTransaction:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_sendPrivateTransaction
-          enum:
-            - eth_sendPrivateTransaction
         params:
           type: array
           minItems: 1
@@ -274,10 +244,8 @@ eth_cancelPrivateTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_cancelPrivateTransaction
-          enum:
-            - eth_cancelPrivateTransaction
         params:
           type: array
           minItems: 1
@@ -295,10 +263,8 @@ eth_getBalance:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getBalance
-          enum:
-            - eth_getBalance
 
 eth_getStorageAt:
   allOf:
@@ -306,10 +272,8 @@ eth_getStorageAt:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getStorageAt
-          enum:
-            - eth_getStorageAt
         params:
           type: array
           description: |
@@ -335,10 +299,8 @@ eth_getCode:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getCode
-          enum:
-            - eth_getCode
 
 eth_accounts:
   allOf:
@@ -346,20 +308,16 @@ eth_accounts:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_accounts
-          enum:
-            - eth_accounts
 eth_getProof:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getProof
-          enum:
-            - eth_getProof
         params:
           description: |
             1. String - 20 Bytes - Address of the account
@@ -395,30 +353,24 @@ eth_protocolVersion:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_protocolVersion
-          enum:
-            - eth_protocolVersion
 eth_gasPrice:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_gasPrice
-          enum:
-            - eth_gasPrice
 eth_estimateGas_550:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_estimateGas
-          enum:
-            - eth_estimateGas
         params:
           type: array
           minItems: 2
@@ -435,10 +387,8 @@ eth_feeHistory:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_feeHistory
-          enum:
-            - eth_feeHistory
         params:
           type: array
           minItems: 3
@@ -469,40 +419,32 @@ eth_maxPriorityFeePerGas:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_maxPriorityFeePerGas
-          enum:
-            - eth_maxPriorityFeePerGas
 eth_chainId:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_chainId
-          enum:
-            - eth_chainId
 net_version:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: net_version
-          enum:
-            - net_version
 net_listening:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: net_listening
-          enum:
-            - net_listening
 eth_getUncleByBlockHashAndIndex:
   allOf:
     - $ref: '#/common_request_fields'
@@ -510,10 +452,8 @@ eth_getUncleByBlockHashAndIndex:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getUncleByBlockHashAndIndex
-          enum:
-            - eth_getUncleByBlockHashAndIndex
 eth_getUncleByBlockNumberAndIndex:
   allOf:
     - $ref: '#/common_request_fields'
@@ -521,20 +461,16 @@ eth_getUncleByBlockNumberAndIndex:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getUncleByBlockNumberAndIndex
-          enum:
-            - eth_getUncleByBlockNumberAndIndex
 eth_getUncleCountByBlockHash:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getUncleCountByBlockHash
-          enum:
-            - eth_getUncleCountByBlockHash
         params:
           type: array
           minItems: 1
@@ -548,10 +484,8 @@ eth_getUncleCountByBlockNumber:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getUncleCountByBlockNumber
-          enum:
-            - eth_getUncleCountByBlockNumber
 eth_getFilterChanges:
   allOf:
     - $ref: '#/common_request_fields'
@@ -559,10 +493,8 @@ eth_getFilterChanges:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getFilterChanges
-          enum:
-            - eth_getFilterChanges
 eth_getFilterLogs:
   allOf:
     - $ref: '#/common_request_fields'
@@ -570,30 +502,24 @@ eth_getFilterLogs:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getFilterLogs
-          enum:
-            - eth_getFilterLogs
 eth_newBlockFilter:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_newBlockFilter
-          enum:
-            - eth_newBlockFilter
 eth_newFilter:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_newFilter
-          enum:
-            - eth_newFilter
         params:
           type: array
           minItems: 1
@@ -606,10 +532,8 @@ eth_newPendingTransactionFilter:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_newPendingTransactionFilter
-          enum:
-            - eth_newPendingTransactionFilter
 eth_uninstallFilter:
   allOf:
     - $ref: '#/common_request_fields'
@@ -617,20 +541,16 @@ eth_uninstallFilter:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_uninstallFilter
-          enum:
-            - eth_uninstallFilter
 web3_clientVersion:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: web3_clientVersion
-          enum:
-            - web3_clientVersion
 web3_sha3:
   allOf:
     - $ref: '#/common_request_fields'
@@ -638,10 +558,8 @@ web3_sha3:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: web3_sha3
-          enum:
-            - web3_sha3
 eth_getTransactionReceiptsByBlock:
   allOf:
     - $ref: '#/common_request_fields'
@@ -649,10 +567,8 @@ eth_getTransactionReceiptsByBlock:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getTransactionReceiptsByBlock
-          enum:
-            - eth_getTransactionReceiptsByBlock
         params:
           type: array
           minItems: 1
@@ -670,10 +586,8 @@ eth_syncing:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_syncing
-          enum:
-            - eth_syncing
 
 # ============= Transaction Receipts API Method ===============
 alchemy_getTransactionReceipts_param:
@@ -682,10 +596,8 @@ alchemy_getTransactionReceipts_param:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: alchemy_getTransactionReceipts
-          enum:
-            - alchemy_getTransactionReceipts
         params:
           type: array
           description: 'The api only takes in one parameter - an object with at least a blockNumber or blockHash. If both are provided, an error is returned asking you to choose either blockNumber or blockHash.'
@@ -712,10 +624,8 @@ alchemy_getTokenAllowance:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: alchemy_getTokenAllowance
-          enum:
-            - alchemy_getTokenAllowance
         params:
           type: array
           description: null
@@ -746,10 +656,8 @@ alchemy_getTokenBalances:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: alchemy_getTokenBalances
-          enum:
-            - alchemy_getTokenBalances
         params:
           type: array
           description: |
@@ -771,10 +679,8 @@ alchemy_getTokenMetadata:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: alchemy_getTokenMetadata
-          enum:
-            - alchemy_getTokenMetadata
         params:
           type: array
           description: 'string, 20 Bytes - Singluar address for the token contract.'
@@ -792,10 +698,8 @@ trace_call:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_call
-          enum:
-            - trace_call
         params:
           type: array
           minItems: 1
@@ -818,10 +722,8 @@ trace_rawTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_rawTransaction
-          enum:
-            - trace_rawTransaction
         params:
           type: array
           minItems: 1
@@ -842,10 +744,8 @@ trace_replayBlockTransactions:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_replayBlockTransactions
-          enum:
-            - trace_replayBlockTransactions
         params:
           type: array
           minItems: 1
@@ -864,10 +764,8 @@ trace_replayTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_replayTransaction
-          enum:
-            - trace_replayTransaction
         params:
           type: array
           minItems: 1
@@ -889,10 +787,8 @@ trace_block:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_block
-          enum:
-            - trace_block
         params:
           type: array
           minItems: 1
@@ -911,10 +807,8 @@ trace_filter:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_filter
-          enum:
-            - trace_filter
         params:
           type: array
           minItems: 1
@@ -954,10 +848,8 @@ trace_get:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_get
-          enum:
-            - trace_get
         params:
           type: array
           description: |
@@ -986,10 +878,8 @@ trace_transaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: trace_transaction
-          enum:
-            - trace_transaction
 
 # ============= Polygon API Methods ===============
 bor_getAuthor:
@@ -998,10 +888,8 @@ bor_getAuthor:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: bor_getAuthor
-          enum:
-            - bor_getAuthor
         params:
           description: Array of block number (in hexadecimal format).
           type: array
@@ -1014,30 +902,24 @@ bor_getCurrentValidators:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: bor_getCurrentValidators
-          enum:
-            - bor_getCurrentValidators
 bor_getCurrentProposer:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: bor_getCurrentProposer
-          enum:
-            - bor_getCurrentProposer
 bor_getRootHash:
   allOf:
     - $ref: '#/common_request_fields'
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: bor_getCurrentProposer
-          enum:
-            - bor_getCurrentProposer
         params:
           type: array
           items:
@@ -1057,10 +939,8 @@ eth_getRootHash:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getRootHash
-          enum:
-            - eth_getRootHash
         params:
           type: array
           items:
@@ -1080,10 +960,8 @@ eth_getSignersAtHash:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_getSignersAtHash
-          enum:
-            - eth_getSignersAtHash
         params:
           type: array
           minItems: 1
@@ -1103,10 +981,8 @@ eth_createAccessList:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_createAccessList
-          enum:
-            - eth_createAccessList
         params:
           type: array
           description: |
@@ -1129,10 +1005,8 @@ alchemy_getAssetTransfers:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: alchemy_getAssetTransfers
-          enum:
-            - alchemy_getAssetTransfers
         params:
           type: array
           minItems: 1
@@ -1221,10 +1095,8 @@ debug_traceCall:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: debug_traceCall
-          enum:
-            - debug_traceCall
         params:
           type: array
           minItems: 1
@@ -1264,10 +1136,8 @@ debug_traceBlockByHash:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: debug_traceBlockByHash
-          enum:
-            - debug_traceBlockByHash
         params:
           type: array
           description: |
@@ -1294,10 +1164,8 @@ debug_traceBlockByNumber:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: debug_traceBlockByNumber
-          enum:
-            - debug_traceBlockByNumber
         params:
           type: array
           description: |
@@ -1322,10 +1190,8 @@ debug_traceTransaction:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: debug_traceTransaction
-          enum:
-            - debug_traceTransaction
         params:
           type: array
           minItems: 1
@@ -1398,10 +1264,8 @@ eth_call_550_gas:
     - type: object
       properties:
         method:
-          type: string
+          $ref: ./components/schemas.yaml#/Method
           default: eth_call
-          enum:
-            - eth_call
         params:
           type: array
           minItems: 1
@@ -1525,10 +1389,8 @@ bundled_signed_transaction_param:
   type: object
   properties:
     method:
-      type: string
+      $ref: ./components/schemas.yaml#/Method
       default: alchemy_sendGasOptimizedTransaction
-      enum:
-        - alchemy_sendGasOptimizedTransaction
     params:
       type: array
       minItems: 1

--- a/sdk_body.yaml
+++ b/sdk_body.yaml
@@ -1,14 +1,14 @@
 # ========= EVM Methods ==============
 eth_getBlock:
   allOf:
-  - type: object
-    properties:
-      params:
-        type: array
-        description: | 
-          One of the following:
-          1. String - Hash associated with the block
-          2. Number - Number associated with the block
+    - type: object
+      properties:
+        params:
+          type: array
+          description: |
+            One of the following:
+            1. String - Hash associated with the block
+            2. Number - Number associated with the block
 eth_getLogs:
   allOf:
     - type: object
@@ -108,17 +108,17 @@ eth_cancelPrivateTransaction:
               txHash:
                 type: string
                 description: Transaction hash for private transaction to be cancelled.
-waitForTransaction: 
-  allOf: 
+waitForTransaction:
+  allOf:
     - type: object
-      properties: 
-        transactionHash: 
+      properties:
+        transactionHash:
           type: string
           description: The hash of the transaction to wait for.
-        confirmations: 
+        confirmations:
           type: number
           description: The number of blocks to wait for.
-        timeout: 
+        timeout:
           type: number
           description: The maximum time to wait for the transaction to confirm.
 eth_getBalance:
@@ -159,7 +159,7 @@ eth_getProof:
     - type: object
       properties:
         params:
-          description: | 
+          description: |
             1. String - 20 Bytes - Address of the account
             2. Array - 32 Bytes - array of storage-keys which should be proofed and included
             3. String - Either the hex value of a **block number** OR One of the following **block tags**: 
@@ -199,14 +199,14 @@ eth_estimateGas_550:
                   - $ref: '#/transaction_object'
                   - $ref: '#/gas_550'
               - $ref: '#/blockNumber_or_blocktag_param_eth'
-sdk_send: 
-  allOf: 
+sdk_send:
+  allOf:
     - type: object
-      properties: 
-        method: 
+      properties:
+        method:
           type: string
           description: The method to call.
-        params: 
+        params:
           type: array
           description: The parameters to pass to the method.
 
@@ -748,11 +748,9 @@ common_request_fields:
   type: object
   properties:
     id:
-      type: integer
-      default: 1
+      $ref: ./components/schemas.yaml#/Id
     jsonrpc:
-      type: string
-      default: '2.0'
+      $ref: ./components/schemas.yaml#/JsonRpc
 filter_options:
   type: object
   properties:
@@ -942,13 +940,12 @@ shaHash_param:
         type: string
         pattern: '^0[xX][0-9a-fA-F]+$'
 
-
 # ======= Definitions for blockNumber methods ==========
 # After the merge, Ethereum offers more block tags than other EVM chains so we separated them out
 
 blockNumber_or_blocktag_param_eth:
   type: string
-  description: | 
+  description: |
     String - Either the hex value of a **block number** OR One of the following **block tags**: 
       * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
       * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
@@ -957,7 +954,7 @@ blockNumber_or_blocktag_param_eth:
       * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
 blockNumber_or_blocktag_param_l2:
   type: string
-  description: | 
+  description: |
     String - Either the hex value of a **block number** OR One of the following **block tags**: 
       * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
       * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
@@ -967,7 +964,7 @@ address_and_blockNumber_param_eth:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         1. String - 20 Bytes - Address
         2. String - Either the hex value of a **block number** OR One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
@@ -984,7 +981,7 @@ address_and_blockNumber_param_l2:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         1. String - 20 Bytes - Address
         2. String - Either the hex value of a **block number** OR One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
@@ -999,7 +996,7 @@ blockNumber_and_index_param_eth:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         1. String - either the hex value of a **block number** OR One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
             * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
@@ -1016,7 +1013,7 @@ blockNumber_and_index_param_eth_l2:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         1. String - either the hex value of a **block number** OR One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
             * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
@@ -1031,7 +1028,7 @@ blockNumber_or_blockHash_param_eth:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         String - One of the following options:
           1. **block hash** 
           2. **block number** (in hex)
@@ -1040,7 +1037,7 @@ blockNumber_or_blockHash_param_eth:
             * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
             * `safe` - The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is “unlikely” to be re-orged. **Only available on Ethereum Goerli**.
             * `finalized` - The most recent crypto-economically secure block, that has been accepted by >2/3 of validators. Cannot be re-orged outside of manual intervention driven by community coordination. Intuitively, this block is very unlikely to be re-orged. **Only available on Ethereum Goerli**.
-            * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.      
+            * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
       minItems: 1
       maxItems: 1
       items:
@@ -1050,14 +1047,14 @@ blockNumber_or_blockHash_param_l2:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         String - One of the following options:
           1. **block hash** 
           2. **block number** (in hex)
           3. One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
             * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
-            * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.      
+            * `earliest` - The lowest numbered block the client has available. Intuitively, you can think of this as the first block created.
       minItems: 1
       maxItems: 1
       items:
@@ -1067,7 +1064,7 @@ blockNumber_uncleIndex_param_eth:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         1. String - either the hex value of a **block number** OR One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
             * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.
@@ -1084,7 +1081,7 @@ blockNumber_uncleIndex_param_l2:
   properties:
     params:
       type: array
-      description: | 
+      description: |
         1. String - either the hex value of a **block number** OR One of the following **block tags**: 
             * `pending` - A sample next block built by the client on top of latest and containing the set of transactions usually taken from local mempool. Intuitively, you can think of these as blocks that have not been mined yet.
             * `latest` - The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions.

--- a/sdk_body.yaml
+++ b/sdk_body.yaml
@@ -78,10 +78,8 @@ eth_sendPrivateTransaction:
       - tx
     properties:
       method:
-        type: string
+        $ref: ./components/schemas.yaml#/Method
         default: eth_sendPrivateTransaction
-        enum:
-          - eth_sendPrivateTransaction
       tx:
         type: string
         description: 'Raw, signed transaction'


### PR DESCRIPTION
After merging this PR the `id` and `jsonrpc` and `method` fields will be hidden from view. Here are some examples on my demo project, before and after merging this PR: 

| Before | After |
| --- | ----------- |
| [`getSlot`](https://alchemy-api-docs.readme.io/reference/getslot-2) | [`getSlot`](https://alchemy-api-docs.readme.io/reference/getslot-4) |
| [`eth_getBlockByHash`](https://alchemy-api-docs.readme.io/reference/eth-getblockbyhash-2) | [`eth_getBlockByHash`](https://alchemy-api-docs.readme.io/reference/eth-getblockbyhash-4) |
| [`eth_getLogs`](https://alchemy-api-docs.readme.io/reference/eth-getlogs-6) | [`eth_getLogs`](https://alchemy-api-docs.readme.io/reference/eth-getlogs-8) |
| [`eth_getStorageAt `](https://alchemy-api-docs.readme.io/reference/eth-getstorageat-2) | [`eth_getStorageAt `](https://alchemy-api-docs.readme.io/reference/eth-getstorageat-4) |

<table>
  <tr>
    <td>
      <p><b>Before</b></p>
      <img src="https://user-images.githubusercontent.com/83442423/221656719-45f684e2-c8d2-453e-afdb-3d2efd0a3209.png" alt="Before Image">
    </td>
    <td>
      <p><b>After</b></p>
      <img src="https://user-images.githubusercontent.com/83442423/221656307-2f87d94f-5fcb-451a-8cde-f26fbf1c06e0.png" alt="After Image">
    </td>
  </tr>
</table>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204028017438981