### PR TITLE
updated getNFTs param ordering

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -23,17 +23,17 @@ paths:
       description: Gets all NFTs currently owned by a given address.
       tags: ['Ownership & Token Gating']
       parameters:
-        - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/owner'
-        - $ref: '#/components/schemas/pageKey'
-        - $ref: '#/components/schemas/pageSize'
         - $ref: '#/components/schemas/contractAddresses'
         - $ref: '#/components/schemas/withMetadata'
-        - $ref: '#/components/schemas/tokenUriTimeoutInMs'
+        - $ref: '#/components/schemas/orderBy'
         - $ref: '#/components/schemas/excludeFilters'
         - $ref: '#/components/schemas/includeFilters'
-        - $ref: '#/components/schemas/orderBy'
         - $ref: '#/components/schemas/spamConfidenceLevel'
+        - $ref: '#/components/schemas/tokenUriTimeoutInMs'
+        - $ref: '#/components/schemas/apiKey'
+        - $ref: '#/components/schemas/pageKey'
+        - $ref: '#/components/schemas/pageSize'
       x-readme:
         samples-languages:
           - javascript


### PR DESCRIPTION
After merging this PR the params of `getNFTs` will be reordered. Here is example of this on my demo project, before and after merging this PR: 

| Before | After |
| --- | ----------- |
| [`getNFTs`](https://docs.alchemy.com/reference/getnfts) | [`getNFTs`](https://alchemy-api-docs.readme.io/reference/getnfts) |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204027480659402