### PR TITLE
added bor_getSignersAtHash and fixed bor_getRootHash

### DIFF
--- a/Polygon/bor_getSignersAtHash.yaml
+++ b/Polygon/bor_getSignersAtHash.yaml
@@ -1,0 +1,39 @@
+openapi: 3.1.0
+info:
+  title: bor_getSignersAtHash - Polygon
+  version: '1.0'
+servers:
+  - url: 'https://polygon-mainnet.g.alchemy.com/v2'
+paths:
+  /{apiKey}:
+    post:
+      summary: bor_getSignersAtHash
+      description: 'Polygon API - Returns all the signers of the block matching the specified block hash.'
+      tags: []
+      parameters:
+        - name: apiKey
+          in: path
+          schema:
+            type: string
+            default: docs-demo
+            description: |
+              <style>
+                .custom-style {
+                  color: #048FF4;
+                }
+              </style>
+              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+          required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/bor_getSignersAtHash
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/bor_getSignersAtHash
+      operationId: bor-getSignersAtHash-polygon

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -919,7 +919,7 @@ bor_getRootHash:
       properties:
         method:
           $ref: ./components/schemas.yaml#/Method
-          default: bor_getCurrentProposer
+          default: bor_getRootHash
         params:
           type: array
           items:

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -933,6 +933,28 @@ bor_getRootHash:
                 type: integer
                 description: Block number (in int format).
                 default: 100
+
+bor_getSignersAtHash:
+  allOf:
+    - $ref: '#/common_request_fields'
+    - type: object
+      properties:
+        method:
+          $ref: ./components/schemas.yaml#/Method
+          default: bor_getSignersAtHash
+        params:
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            type: object
+            properties:
+              blockHash:
+                type: string
+                description: Block hash (in hexadecimal format).
+                default: '0x1890044c3e2cbd530f0a9a6d0d77f238866d725ddd801d34fa42c5e062fc7d62'
+                pattern: '^0[xX][0-9a-fA-F]+$'
+
 eth_getRootHash:
   allOf:
     - $ref: '#/common_request_fields'

--- a/evm_examples.yaml
+++ b/evm_examples.yaml
@@ -2139,6 +2139,22 @@ bor_getRootHash:
     'result': '0x9ead03f7136fc6b4bdb0780b00a1c14ae5a8b6d0',
   }
 
+bor_getSignersAtHash:
+  {
+    'jsonrpc': '2.0',
+    'id': 1,
+    'result':
+      [
+        '0xbadeb474d3bef72e9058ea6aed0806004f548318',
+        '0x75dddfb045c0f0ef72d940fe935bf36e773eb05b',
+        '0x2e27a9669487d40299e526f86cb1ce8954b84b12',
+        '0xda73a58f632ab9a3f095a304275ad10093c1ce88',
+        '0x777ad55efc465052d6a4ab7bc75b6a15175bb399',
+        '0x550365027554bd20d750f9361e460c7428ffbd75',
+        '0x7bf377f69da0e46da1502d5f2bcf9fb00c3b610b',
+      ],
+  }
+
 eth_getSignersAtHash:
   {
     'jsonrpc': '2.0',

--- a/evm_responses.yaml
+++ b/evm_responses.yaml
@@ -1023,6 +1023,18 @@ bor_getRootHash:
           type: string
       example:
         $ref: ./evm_examples.yaml#/bor_getRootHash
+bor_getSignersAtHash:
+  allOf:
+    - $ref: '#/common_response_fields'
+    - type: object
+      properties:
+        result:
+          description: Array of signers for the specified block hash
+          type: array
+          items:
+            type: string
+      example:
+        $ref: ./evm_examples.yaml#/bor_getSignersAtHash
 eth_getSignersAtHash:
   allOf:
     - $ref: '#/common_response_fields'


### PR DESCRIPTION
1. Added a new method [`bor_getSignersAtHash`](https://alchemy-test.readme.io/reference/bor-getsignersathash-polygon) to Polygon APIs: 
Check it out live in test project by [clicking here](https://alchemy-test.readme.io/reference/bor-getsignersathash-polygon).

2. Fixed the wrong method name in example curl request of [`bor_getRootHash`](https://alchemy-test.readme.io/reference/bor-getroothash-polygon)
Check it out live in test project by [clicking here](https://alchemy-test.readme.io/reference/bor-getroothash-polygon).

