### PR TITLE
added zkevm methods that always return empty or 0 response

### DIFF
--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1492,7 +1492,10 @@ signed_transaction_param:
       items:
         type: string
         pattern: '^0[xX][0-9a-fA-F]+$'
-      default: ['0x']
+      default:
+        [
+          '0xf86d808504a817c800825208943535353535353535353535353535353535353535880de0b6b3a7640000801ca0e0d2e3f3d8de8a0c9f25d0b02c7a8a91e7e1c818e6f37a49d8b04f9a9a96a1a0620a6c8d95e0f289bfbf2b3d3e476de6b9bc6d0e974c06f1e4de5be7c5ef0e10',
+        ]
 get_signed_txns_status_param:
   type: object
   properties:

--- a/polygon-zkevm/eth_getCompilers.yaml
+++ b/polygon-zkevm/eth_getCompilers.yaml
@@ -1,0 +1,78 @@
+openapi: 3.1.0
+info:
+  title: eth_getCompilers - Polygon zkEVM
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - polygonzkevm-mainnet
+          - polygonzkevm-testnet
+        default: polygonzkevm-testnet
+paths:
+  /{apiKey}:
+    $ref: '#/components/pathItems/path'
+components:
+  pathItems:
+    path:
+      post:
+        summary: eth_getCompilers - Polygon zkEVM
+        description: Response is always empty in Polygon zkEVM.
+        tags: []
+        parameters:
+          - name: apiKey
+            in: path
+            schema:
+              type: string
+              default: docs-demo
+              description: |
+                <style>
+                  .custom-style {
+                    color: #048FF4;
+                  }
+                </style>
+                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+            required: true
+        requestBody:
+          description: Accepts nothing.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    $ref: ../components/schemas.yaml#/Id
+                  jsonrpc:
+                    $ref: ../components/schemas.yaml#/JsonRpc
+                  method:
+                    $ref: ../components/schemas.yaml#/Method
+                    default: eth_getCompilers
+        x-readme:
+          samples-languages:
+            - curl
+            - javascript
+            - python
+            - go
+        responses:
+          '200':
+            description: Response is always empty.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - id
+                    - jsonrpc
+                    - result
+                  properties:
+                    id:
+                      $ref: ../components/schemas.yaml#/Id
+                    jsonrpc:
+                      $ref: ../components/schemas.yaml#/JsonRpc
+                    result:
+                      type: array
+                      items:
+                        type: string
+                      example: []
+        operationId: eth-getCompilers-polygon-zkevm

--- a/polygon-zkevm/eth_getCompilers.yaml
+++ b/polygon-zkevm/eth_getCompilers.yaml
@@ -18,7 +18,7 @@ components:
     path:
       post:
         summary: eth_getCompilers - Polygon zkEVM
-        description: Response is always empty in Polygon zkEVM.
+        description: Returns a list of installed compilers (Deprecated). Response is always empty in Polygon zkEVM.
         tags: []
         parameters:
           - name: apiKey

--- a/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
@@ -1,0 +1,63 @@
+openapi: 3.1.0
+info:
+  title: eth_getUncleByBlockHashAndIndex - Polygon zkEVM
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - polygonzkevm-mainnet
+          - polygonzkevm-testnet
+        default: polygonzkevm-testnet
+paths:
+  /{apiKey}:
+    $ref: '#/components/pathItems/path'
+components:
+  pathItems:
+    path:
+      post:
+        summary: eth_getUncleByBlockHashAndIndex - Polygon zkEVM
+        description: Response is always empty on Polygon zkEVM.
+        tags: []
+        parameters:
+          - name: apiKey
+            in: path
+            schema:
+              type: string
+              default: docs-demo
+              description: |
+                <style>
+                  .custom-style {
+                    color: #048FF4;
+                  }
+                </style>
+                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+            required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_body.yaml#/eth_getUncleByBlockHashAndIndex
+        responses:
+          '200':
+            description: Response is always empty.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - id
+                    - jsonrpc
+                    - result
+                  properties:
+                    id:
+                      $ref: ../components/schemas.yaml#/Id
+                    jsonrpc:
+                      $ref: ../components/schemas.yaml#/JsonRpc
+                    result:
+                      type: array
+                      items:
+                        type: string
+                      example: []
+        operationId: eth-getUncleByBlockHashAndIndex-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
@@ -18,7 +18,7 @@ components:
     path:
       post:
         summary: eth_getUncleByBlockHashAndIndex - Polygon zkEVM
-        description: Response is always empty on Polygon zkEVM.
+        description: Returns information about an uncle block by block hash and uncle index position. Response for this method is always empty on Polygon zkEVM.
         tags: []
         parameters:
           - name: apiKey

--- a/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
@@ -18,7 +18,7 @@ components:
     path:
       post:
         summary: eth_getUncleByBlockNumberAndIndex - Polygon zkEVM
-        description: Response is always empty on Polygon zkEVM.
+        description: Returns information about an uncle block by block number and uncle index position. Response for this method is always empty on Polygon zkEVM.
         tags: []
         parameters:
           - name: apiKey

--- a/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
@@ -1,0 +1,63 @@
+openapi: 3.1.0
+info:
+  title: eth_getUncleByBlockNumberAndIndex - Polygon zkEVM
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - polygonzkevm-mainnet
+          - polygonzkevm-testnet
+        default: polygonzkevm-testnet
+paths:
+  /{apiKey}:
+    $ref: '#/components/pathItems/path'
+components:
+  pathItems:
+    path:
+      post:
+        summary: eth_getUncleByBlockNumberAndIndex - Polygon zkEVM
+        description: Response is always empty on Polygon zkEVM.
+        tags: []
+        parameters:
+          - name: apiKey
+            in: path
+            schema:
+              type: string
+              default: docs-demo
+              description: |
+                <style>
+                  .custom-style {
+                    color: #048FF4;
+                  }
+                </style>
+                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+            required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_body.yaml#/eth_getUncleByBlockNumberAndIndex
+        responses:
+          '200':
+            description: Response is always empty.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - id
+                    - jsonrpc
+                    - result
+                  properties:
+                    id:
+                      $ref: ../components/schemas.yaml#/Id
+                    jsonrpc:
+                      $ref: ../components/schemas.yaml#/JsonRpc
+                    result:
+                      type: array
+                      items:
+                        type: string
+                      example: []
+        operationId: eth-getUncleByBlockNumberAndIndex-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
@@ -18,7 +18,7 @@ components:
     path:
       post:
         summary: eth_getUncleCountByBlockHash - Polygon zkEVM
-        description: Response for this method is always 0 on Polygon zkEVM.
+        description: Returns the number of uncles in a block specified by block hash. Response for this method is always 0 on Polygon zkEVM.
         tags: []
         parameters:
           - name: apiKey

--- a/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
@@ -1,0 +1,67 @@
+openapi: 3.1.0
+info:
+  title: eth_getUncleCountByBlockHash - Polygon zkEVM
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - polygonzkevm-mainnet
+          - polygonzkevm-testnet
+        default: polygonzkevm-testnet
+paths:
+  /{apiKey}:
+    $ref: '#/components/pathItems/path'
+components:
+  pathItems:
+    path:
+      post:
+        summary: eth_getUncleCountByBlockHash - Polygon zkEVM
+        description: Response for this method is always 0 on Polygon zkEVM.
+        tags: []
+        parameters:
+          - name: apiKey
+            in: path
+            schema:
+              type: string
+              default: docs-demo
+              description: |
+                <style>
+                  .custom-style {
+                    color: #048FF4;
+                  }
+                </style>
+                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+            required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_body.yaml#/eth_getUncleCountByBlockHash
+        x-readme:
+          samples-languages:
+            - curl
+            - javascript
+            - python
+            - go
+        responses:
+          '200':
+            description: Response is always 0.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - id
+                    - jsonrpc
+                    - result
+                  properties:
+                    id:
+                      $ref: ../components/schemas.yaml#/Id
+                    jsonrpc:
+                      $ref: ../components/schemas.yaml#/JsonRpc
+                    result:
+                      type: integer
+                      example: 0
+        operationId: eth-getUncleCountByBlockHash-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
@@ -1,0 +1,67 @@
+openapi: 3.1.0
+info:
+  title: eth_getUncleCountByBlockNumber - Polygon zkEVM
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - polygonzkevm-mainnet
+          - polygonzkevm-testnet
+        default: polygonzkevm-testnet
+paths:
+  /{apiKey}:
+    $ref: '#/components/pathItems/path'
+components:
+  pathItems:
+    path:
+      post:
+        summary: eth_getUncleCountByBlockNumber - Polygon zkEVM
+        description: Response for this method is always 0 on Polygon zkEVM.
+        tags: []
+        parameters:
+          - name: apiKey
+            in: path
+            schema:
+              type: string
+              default: docs-demo
+              description: |
+                <style>
+                  .custom-style {
+                    color: #048FF4;
+                  }
+                </style>
+                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+            required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_body.yaml#/eth_getUncleCountByBlockNumber
+        x-readme:
+          samples-languages:
+            - curl
+            - javascript
+            - python
+            - go
+        responses:
+          '200':
+            description: Response is always 0.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - id
+                    - jsonrpc
+                    - result
+                  properties:
+                    id:
+                      $ref: ../components/schemas.yaml#/Id
+                    jsonrpc:
+                      $ref: ../components/schemas.yaml#/JsonRpc
+                    result:
+                      type: integer
+                      example: 0
+        operationId: eth-getUncleCountByBlockNumber-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
@@ -18,7 +18,7 @@ components:
     path:
       post:
         summary: eth_getUncleCountByBlockNumber - Polygon zkEVM
-        description: Response for this method is always 0 on Polygon zkEVM.
+        description: Returns the number of uncles in a block specified by block number. Response for this method is always 0 on Polygon zkEVM.
         tags: []
         parameters:
           - name: apiKey

--- a/polygon-zkevm/eth_protocolVersion.yaml
+++ b/polygon-zkevm/eth_protocolVersion.yaml
@@ -1,0 +1,67 @@
+openapi: 3.1.0
+info:
+  title: eth_protocolVersion - Polygon zkEVM
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - polygonzkevm-mainnet
+          - polygonzkevm-testnet
+        default: polygonzkevm-testnet
+paths:
+  /{apiKey}:
+    $ref: '#/components/pathItems/path'
+components:
+  pathItems:
+    path:
+      post:
+        summary: eth_protocolVersion - Polygon zkEVM
+        description: Response for this method is always 0 on Polygon zkEVM.
+        tags: []
+        parameters:
+          - name: apiKey
+            in: path
+            schema:
+              type: string
+              default: docs-demo
+              description: |
+                <style>
+                  .custom-style {
+                    color: #048FF4;
+                  }
+                </style>
+                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+            required: true
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_body.yaml#/eth_protocolVersion
+        x-readme:
+          samples-languages:
+            - curl
+            - javascript
+            - python
+            - go
+        responses:
+          '200':
+            description: Response is always 0.
+            content:
+              application/json:
+                schema:
+                  type: object
+                  required:
+                    - id
+                    - jsonrpc
+                    - result
+                  properties:
+                    id:
+                      $ref: ../components/schemas.yaml#/Id
+                    jsonrpc:
+                      $ref: ../components/schemas.yaml#/JsonRpc
+                    result:
+                      type: integer
+                      example: 0
+        operationId: eth-protocolVersion-polygon-zkevm

--- a/polygon-zkevm/eth_protocolVersion.yaml
+++ b/polygon-zkevm/eth_protocolVersion.yaml
@@ -18,7 +18,7 @@ components:
     path:
       post:
         summary: eth_protocolVersion - Polygon zkEVM
-        description: Response for this method is always 0 on Polygon zkEVM.
+        description: Returns the current network protocol version as a string. Response for this method is always 0 on Polygon zkEVM.
         tags: []
         parameters:
           - name: apiKey


### PR DESCRIPTION
These methods were added as part of this PR: 

- [eth_getCompilers](https://alchemy-test.readme.io/reference/eth-getcompilers-polygon-zkevm-1)
- [eth_getUncleByBlockHashAndIndex](https://alchemy-test.readme.io/reference/eth-getunclebyblockhashandindex-polygon-zkevm-1)
- [eth_getUncleByBlockNumberAndIndex](https://alchemy-test.readme.io/reference/eth-getunclebyblocknumberandindex-polygon-zkevm)
- [eth_getUncleCountByBlockHash](https://alchemy-test.readme.io/reference/eth-getunclecountbyblockhash-polygon-zkevm)
- [eth_getUncleCountByBlockNumber](https://alchemy-test.readme.io/reference/eth-getunclecountbyblocknumber-polygon-zkevm)
- [eth_protocolVersion](https://alchemy-test.readme.io/reference/eth-protocolversion-polygon-zkevm)