### PR TITLE
deprecate `DEFAULT_TOKENS` in `alchemy_getTokenBalances`

### DIFF
--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -738,11 +738,13 @@ alchemy_getTokenBalances:
           type: array
           description: |
             1. String, 20 Bytes - The address to check token balances for.
-            2. OneOf the following token specifications, defaults to `erc20`
-              - **[omitted below]** Array - A list of contract addresses. Suggested limit: 100 addresses
-              - The String `DEFAULT_TOKENS` - denotes a query for the top 100 tokens by 24 hour volume - only available on Mainnet for Ethereum, Polygon, and Arbitrum **[Deprecated - use `erc20` instead]**
-              - The String `erc20` - denotes the set of erc20 tokens that the address has ever held.
-            3. **[omitted below]**  Object `pageKey` - A string address used for pagination. If more results are available, a pageKey will be returned in the response.
+            2. One of the following token specifications, defaults to `erc20`
+                1. The String `erc20` - denotes the set of erc20 tokens that the address has ever held.
+                2. Array - A list of contract addresses. Suggested limit: 100 addresses **[omitted below]**
+                3. The String `DEFAULT_TOKENS` - denotes a query for the top 100 tokens by 24 hour volume - only available on Mainnet for Ethereum, Polygon, and Arbitrum. **[deprecated, please use `erc20` instead]**
+            3. Options (optional) - An object that contains the following settings **[omitted below]**:
+                1. `pageKey`: Applies only to the `erc20` request type. A string address used for pagination. If more results are available, a `pageKey` will be returned in the response.
+                2. `maxCount`: Applies only to the `erc20` request type. Specifies the maximum count of token balances to return per call. This value defaults to 100 and is currently capped at 100.
           minItems: 1
           maxItems: 2
           items:

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -740,7 +740,7 @@ alchemy_getTokenBalances:
             1. String, 20 Bytes - The address to check token balances for.
             2. OneOf the following token specifications, defaults to `erc20`
               - **[omitted below]** Array - A list of contract addresses. Suggested limit: 100 addresses
-              - The String `DEFAULT_TOKENS` - denotes a query for the top 100 tokens by 24 hour volume - only available on Mainnet for Ethereum, Polygon, and Arbitrum.
+              - **[Deprecated - use `erc20` instead]** The String `DEFAULT_TOKENS` - denotes a query for the top 100 tokens by 24 hour volume - only available on Mainnet for Ethereum, Polygon, and Arbitrum.
               - The String `erc20` - denotes the set of erc20 tokens that the address has ever held.
             3. **[omitted below]**  Object `pageKey` - A string address used for pagination. If more results are available, a pageKey will be returned in the response.
           minItems: 1

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -740,7 +740,7 @@ alchemy_getTokenBalances:
             1. String, 20 Bytes - The address to check token balances for.
             2. OneOf the following token specifications, defaults to `erc20`
               - **[omitted below]** Array - A list of contract addresses. Suggested limit: 100 addresses
-              - **[Deprecated - use `erc20` instead]** The String `DEFAULT_TOKENS` - denotes a query for the top 100 tokens by 24 hour volume - only available on Mainnet for Ethereum, Polygon, and Arbitrum.
+              - The String `DEFAULT_TOKENS` - denotes a query for the top 100 tokens by 24 hour volume - only available on Mainnet for Ethereum, Polygon, and Arbitrum **[Deprecated - use `erc20` instead]**
               - The String `erc20` - denotes the set of erc20 tokens that the address has ever held.
             3. **[omitted below]**  Object `pageKey` - A string address used for pagination. If more results are available, a pageKey will be returned in the response.
           minItems: 1


### PR DESCRIPTION
Live staging link: https://alchemy-test.readme.io/reference/alchemy-gettokenbalances-1

![image](https://github.com/alchemyplatform/docs-openapi-specs/assets/83442423/9844a1c2-557a-418f-a78c-de683b175a82)
