### PR TITLE
update the request body for `alchemy_requestPaymasterData`

### DIFF
--- a/components/schemas.yaml
+++ b/components/schemas.yaml
@@ -98,7 +98,7 @@ Method:
 
 
 UserOperationPartial:
-  title: User Operation Partial
+  title: User Operation ( missing signature, paymasterData, and gas fields )
   type: object
   properties:
     sender:
@@ -119,17 +119,13 @@ UserOperationPartial:
         Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the user operation.
       default: '0xb61d27f60000000000000000000000000be71941d041a32fe7df4a61eb2fcff3b03502c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000004d087d28800000000000000000000000000000000000000000000000000000000'
 
-UserOperation:
-  title: User Operation
+UserOperationPartialWithGasFields:
+  title: User Operation ( missing signature and paymasterData ) 
   type: object
   allOf:
     - $ref: '#/UserOperationPartial'
     - type: object
       properties:
-        signature:
-          $ref: '#/Hex'
-          description: Data passed into the account along with the nonce during the verification step
-          default: '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c'
         callGasLimit:
           $ref: '#/Hex'
           description: The amount of gas to allocate the main execution call
@@ -145,6 +141,18 @@ UserOperation:
         maxPriorityFeePerGas:
           $ref: '#/Hex'
           description: Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)
+
+UserOperation:
+  title: User Operation
+  type: object
+  allOf:
+    - $ref: '#/UserOperationPartialWithGasFields'
+    - type: object
+      properties:
+        signature:
+          $ref: '#/Hex'
+          description: Data passed into the account along with the nonce during the verification step
+          default: '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c'
         paymasterAndData:
           $ref: '#/Hex'
           description: Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -2112,7 +2112,7 @@ alchemy_requestPaymasterAndData:
               entryPoint:
                 $ref: ./components/schemas.yaml#/EntryPoint
               userOperation:
-                $ref: ./components/schemas.yaml#/UserOperation
+                $ref: ./components/schemas.yaml#/UserOperationPartialWithGasFields
                 description: Partial UserOperation object, missing paymasterAndData and signature fields
 
 alchemy_requestGasAndPaymasterAndData:


### PR DESCRIPTION
Update the request body for `alchemy_requestPaymasterData` to remove `paymasterData` and `signature` fields as they are not required there.

This PR builds on top of existing `UserOperationPartial` component to make another component called `UserOperationPartialWithGasFields` that is the desired `userOperation` component in the request structure of `alchemy_requestPaymasterData`, and further it builds the final full `UserOperation` object on top of `UserOperationPartialWithGasFields`.

Affected Methods with live staging pages:

- [`alchemy_requestPaymasterAndData`](https://alchemy-test.readme.io/reference/alchemy-requestpaymasteranddata): External Changes - Removed `paymasterData` and `signature` fields from the `userOperation` object in request.

- [`alchemy_requestGasAndPaymasterAndData`](https://alchemy-test.readme.io/reference/alchemy-requestgasandpaymasteranddata-1): External Change - updated the title for `userOperation` object in request.

- [`eth_sendUserOperation`](https://alchemy-test.readme.io/reference/eth-senduseroperation-1): Internal Change - component of `userOperation` object in request now builds on top of another component. No visual changes.

- [`eth_estimateUserOperationGas`](https://alchemy-test.readme.io/reference/eth-estimateuseroperationgas-1):  Internal Change - component of `userOperation` object in request now builds on top of another component. No visual changes.