### PR TITLE
optimism bedrock upgrades

### DIFF
--- a/debug/debug_traceCall.yaml
+++ b/debug/debug_traceCall.yaml
@@ -13,6 +13,7 @@ servers:
           - polygon-mumbai
           - arb-mainnet
           - arb-goerli
+          - opt-mainnet
           - opt-goerli
         default: eth-mainnet
 paths:


### PR DESCRIPTION
- add support for `opt-mainnet` to `debug_traceCall`

`debug_traceCall` live page in staging: https://alchemy-test.readme.io/reference/debug-tracecall-2

![image](https://github.com/alchemyplatform/docs-openapi-specs/assets/83442423/72f387b2-1352-4b8b-9215-da2eb0993123)
