### PR TITLE
Add starknet_estimateMessageFee new method

### DIFF
--- a/components/starknet/schemas.yaml
+++ b/components/starknet/schemas.yaml
@@ -1168,3 +1168,30 @@ TooManyKeysInFilter:
 ContractError:
   code: 40
   message: 'Contract error'
+
+MSG_FROM_L1:
+  title: Message from L1
+  type: object
+  properties:
+    from_address:
+      description: The address of the L1 contract sending the message
+      $ref: '#/EthAddress'
+    to_address:
+      title: To address
+      description: The target L2 address the message is sent to
+      $ref: '#/Address'
+    entry_point_selector:
+      title: Selector
+      description: The selector of the l1_handler to invoke in the target contract
+      $ref: '#/Felt'
+    payload:
+      title: Payload
+      description: The payload of the message
+      type: array
+      items:
+        $ref: '#/Felt'
+  required:
+    - from_address
+    - to_address
+    - payload
+    - entry_point_selector

--- a/components/starknet/schemas.yaml
+++ b/components/starknet/schemas.yaml
@@ -1176,6 +1176,7 @@ MSG_FROM_L1:
     from_address:
       description: The address of the L1 contract sending the message
       $ref: '#/EthAddress'
+      default: '0xAbCdEf0123456789aBcDeF0123456789AbCdEf01'
     to_address:
       title: To address
       description: The target L2 address the message is sent to
@@ -1184,6 +1185,7 @@ MSG_FROM_L1:
       title: Selector
       description: The selector of the l1_handler to invoke in the target contract
       $ref: '#/Felt'
+      default: '0x00000'
     payload:
       title: Payload
       description: The payload of the message

--- a/starknet/starknet_estimateMessageFee.yaml
+++ b/starknet/starknet_estimateMessageFee.yaml
@@ -1,0 +1,60 @@
+openapi: 3.1.0
+info:
+  title: starknet_estimateMessageFee
+  description: Estimate the L2 fee of a message sent on L1
+  version: '1.0'
+servers:
+  - url: 'https://{network}.g.alchemy.com/v2/'
+    variables:
+      network:
+        enum:
+          - starknet-mainnet
+          - starknet-goerli
+        default: starknet-mainnet
+paths:
+  /{apiKey}:
+    post:
+      operationId: starknet-estimateMessageFee
+      summary: starknet_estimateMessageFee
+      description: Estimates the resources required by the l1_handler transaction induced by the message
+      parameters:
+        - name: apiKey
+          in: path
+          schema:
+            type: string
+            default: docs-demo
+          description: |
+            <style>
+              .custom-style {
+                color: #048FF4;
+              }
+            </style>
+            For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
+          required: true
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: starknet_estimateMessageFee
+                params:
+                  type: array
+                  title: Params
+                  description: The message's parameters and the block_id for the block referencing the state or call the transaction on.
+                  minItems: 2
+                  maxItems: 2
+                  items:
+                    oneOf:
+                      - $ref: '../components/starknet/schemas.yaml#/MSG_FROM_L1'
+                      - $ref: '../components/starknet/schemas.yaml#/BlockId'
+      responses:
+        '200':
+          description: the fee estimation
+          content:
+            application/json:
+              schema:
+                $ref: '../components/starknet/schemas.yaml#/FeeEstimate'


### PR DESCRIPTION
A new method, `starknet_estimateMessageFee`, was added to the starknet JSON RPC API: https://github.com/starkware-libs/starknet-specs/blob/27e29cd9c107b1b629a99f12f0b7968c7a7c4e98/api/starknet_api_openrpc.json#L585C22-L585C49

We added this to our docs to reflect it. Here is the sample page in demo project: 

https://alchemy-test.readme.io/reference/starknet-estimatemessagefee-1

![image](https://github.com/alchemyplatform/docs-openapi-specs/assets/83442423/31a0e86d-8016-4b2a-be03-5e355dee38c8)
