### PR TITLE
Docs fix for custom webhooks variable create API

### DIFF
--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -773,7 +773,7 @@ components:
       properties:
         items:
           type: array
-          description: 'A variable defined as a set of addresses or byte32 elements, use [] if none.'
+          description: 'A variable defined as a set of addresses or byte32 elements. Must be a non-empty list.'
           default: []
           items:
             type: string


### PR DESCRIPTION
fixing docs for custom webhooks variable create API argument description
-  items field to specify non empty list required