### PR TITLE
Bm/refactor evm specs

### DIFF
--- a/account-abstraction/alchemy_requestGasAndPaymasterAndData.yaml
+++ b/account-abstraction/alchemy_requestGasAndPaymasterAndData.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: alchemy_requestGasAndPaymasterAndData
       description: Requests gas and coverage for a `UserOperation`. Returns `paymasterAndData` and gas parameters if approved, errors if not. Optionally accepts fee parameter overrides to be used in the `UserOperation`.
       operationId: alchemy-requestGasAndPaymasterAndData

--- a/account-abstraction/alchemy_requestGasAndPaymasterAndData.yaml
+++ b/account-abstraction/alchemy_requestGasAndPaymasterAndData.yaml
@@ -30,19 +30,7 @@ components:
         description: Requests gas and coverage for a `UserOperation`. Returns `paymasterAndData` and gas parameters if approved, errors if not. Optionally accepts fee parameter overrides to be used in the `UserOperation`.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/alchemy_requestGasAndPaymasterAndData.yaml
+++ b/account-abstraction/alchemy_requestGasAndPaymasterAndData.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: alchemy_requestGasAndPaymasterAndData
-        description: Requests gas and coverage for a `UserOperation`. Returns `paymasterAndData` and gas parameters if approved, errors if not. Optionally accepts fee parameter overrides to be used in the `UserOperation`.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: alchemy_requestGasAndPaymasterAndData
+      description: Requests gas and coverage for a `UserOperation`. Returns `paymasterAndData` and gas parameters if approved, errors if not. Optionally accepts fee parameter overrides to be used in the `UserOperation`.
+      operationId: alchemy-requestGasAndPaymasterAndData
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/alchemy_requestGasAndPaymasterAndData
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/alchemy_requestGasAndPaymasterAndData
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/alchemy_requestGasAndPaymasterAndData
-        operationId: alchemy-requestGasAndPaymasterAndData
+                $ref: ../evm_responses.yaml#/alchemy_requestGasAndPaymasterAndData
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/alchemy_requestPaymasterAndData.yaml
+++ b/account-abstraction/alchemy_requestPaymasterAndData.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: alchemy_requestPaymasterAndData
       description: Requests coverage for a `UserOperation`. Returns `paymasterAndData` if approved, errors if not.
       operationId: alchemy-requestPaymasterAndData

--- a/account-abstraction/alchemy_requestPaymasterAndData.yaml
+++ b/account-abstraction/alchemy_requestPaymasterAndData.yaml
@@ -30,19 +30,7 @@ components:
         description: Requests coverage for a `UserOperation`. Returns `paymasterAndData` if approved, errors if not.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/alchemy_requestPaymasterAndData.yaml
+++ b/account-abstraction/alchemy_requestPaymasterAndData.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: alchemy_requestPaymasterAndData
-        description: Requests coverage for a `UserOperation`. Returns `paymasterAndData` if approved, errors if not.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: alchemy_requestPaymasterAndData
+      description: Requests coverage for a `UserOperation`. Returns `paymasterAndData` if approved, errors if not.
+      operationId: alchemy-requestPaymasterAndData
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/alchemy_requestPaymasterAndData
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/alchemy_requestPaymasterAndData
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/alchemy_requestPaymasterAndData
-        operationId: alchemy-requestPaymasterAndData
+                $ref: ../evm_responses.yaml#/alchemy_requestPaymasterAndData
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/eth_estimateUserOperationGas.yaml
+++ b/account-abstraction/eth_estimateUserOperationGas.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_estimateUserOperationGas
-        description: Estimates the gas values for a `UserOperation`.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: eth_estimateUserOperationGas
+      description: Estimates the gas values for a `UserOperation`.
+      operationId: eth-estimateUserOperationGas
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_estimateUserOperationGas
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_estimateUserOperationGas
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_estimateUserOperationGas
-        operationId: eth-estimateUserOperationGas
+                $ref: ../evm_responses.yaml#/eth_estimateUserOperationGas
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/eth_estimateUserOperationGas.yaml
+++ b/account-abstraction/eth_estimateUserOperationGas.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_estimateUserOperationGas
       description: Estimates the gas values for a `UserOperation`.
       operationId: eth-estimateUserOperationGas

--- a/account-abstraction/eth_estimateUserOperationGas.yaml
+++ b/account-abstraction/eth_estimateUserOperationGas.yaml
@@ -30,19 +30,7 @@ components:
         description: Estimates the gas values for a `UserOperation`.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/eth_getUserOperationByHash.yaml
+++ b/account-abstraction/eth_getUserOperationByHash.yaml
@@ -30,19 +30,7 @@ components:
         description: Return a `UserOperation` based on a hash (`userOpHash`).
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/eth_getUserOperationByHash.yaml
+++ b/account-abstraction/eth_getUserOperationByHash.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getUserOperationByHash
       description: Return a `UserOperation` based on a hash (`userOpHash`).
       operationId: eth-getUserOperationByHash

--- a/account-abstraction/eth_getUserOperationByHash.yaml
+++ b/account-abstraction/eth_getUserOperationByHash.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getUserOperationByHash
-        description: Return a `UserOperation` based on a hash (`userOpHash`).
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: eth_getUserOperationByHash
+      description: Return a `UserOperation` based on a hash (`userOpHash`).
+      operationId: eth-getUserOperationByHash
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getUserOperationByHash
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getUserOperationByHash
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getUserOperationByHash
-        operationId: eth-getUserOperationByHash
+                $ref: ../evm_responses.yaml#/eth_getUserOperationByHash
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/eth_getUserOperationReceipt.yaml
+++ b/account-abstraction/eth_getUserOperationReceipt.yaml
@@ -30,19 +30,7 @@ components:
         description: Get the `UserOperationReceipt` based on the `userOpHash` value.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/eth_getUserOperationReceipt.yaml
+++ b/account-abstraction/eth_getUserOperationReceipt.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getUserOperationReceipt
-        description: Get the `UserOperationReceipt` based on the `userOpHash` value.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: eth_getUserOperationReceipt
+      description: Get the `UserOperationReceipt` based on the `userOpHash` value.
+      operationId: eth-getUserOperationReceipt
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getUserOperationReceipt
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getUserOperationReceipt
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getUserOperationReceipt
-        operationId: eth-getUserOperationReceipt
+                $ref: ../evm_responses.yaml#/eth_getUserOperationReceipt
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/eth_getUserOperationReceipt.yaml
+++ b/account-abstraction/eth_getUserOperationReceipt.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getUserOperationReceipt
       description: Get the `UserOperationReceipt` based on the `userOpHash` value.
       operationId: eth-getUserOperationReceipt

--- a/account-abstraction/eth_sendUserOperation.yaml
+++ b/account-abstraction/eth_sendUserOperation.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_sendUserOperation
-        description: Sends a user operation to the given EVM network.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: eth_sendUserOperation
+      description: Sends a user operation to the given EVM network.
+      operationId: eth-sendUserOperation
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_sendUserOperation
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_sendUserOperation
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_sendUserOperation
-        operationId: eth-sendUserOperation
+                $ref: ../evm_responses.yaml#/eth_sendUserOperation
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/eth_sendUserOperation.yaml
+++ b/account-abstraction/eth_sendUserOperation.yaml
@@ -30,19 +30,7 @@ components:
         description: Sends a user operation to the given EVM network.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/eth_sendUserOperation.yaml
+++ b/account-abstraction/eth_sendUserOperation.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_sendUserOperation
       description: Sends a user operation to the given EVM network.
       operationId: eth-sendUserOperation

--- a/account-abstraction/eth_supportedEntryPoints.yaml
+++ b/account-abstraction/eth_supportedEntryPoints.yaml
@@ -21,32 +21,28 @@ servers:
         default: eth-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_supportedEntryPoints
-        description: Returns an array of the `entryPoint` addresses supported by the client.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          required: true
+    post:
+      tags: []
+      summary: eth_supportedEntryPoints
+      description: Returns an array of the `entryPoint` addresses supported by the client.
+      operationId: eth-supportedEntryPoints
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_supportedEntryPoints
+      responses:
+        '200':
+          description: Successful response
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_supportedEntryPoints
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Successful response
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_supportedEntryPoints
-        operationId: eth-supportedEntryPoints
+                $ref: ../evm_responses.yaml#/eth_supportedEntryPoints
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/account-abstraction/eth_supportedEntryPoints.yaml
+++ b/account-abstraction/eth_supportedEntryPoints.yaml
@@ -30,19 +30,7 @@ components:
         description: Returns an array of the `entryPoint` addresses supported by the client.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           required: true
           content:

--- a/account-abstraction/eth_supportedEntryPoints.yaml
+++ b/account-abstraction/eth_supportedEntryPoints.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_supportedEntryPoints
       description: Returns an array of the `entryPoint` addresses supported by the client.
       operationId: eth-supportedEntryPoints

--- a/account-abstraction/rundler_maxPriorityFeePerGas.yaml
+++ b/account-abstraction/rundler_maxPriorityFeePerGas.yaml
@@ -22,9 +22,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: rundler_maxPriorityFeePerGas
       description: 'Returns a fee per gas that is an estimate of how much users should set as a priority fee in UOs for Rundler endpoints.'
-      tags: []
+      operationId: rundler-maxPriorityFeePerGas
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -39,4 +40,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/string_result_response
-      operationId: rundler-maxPriorityFeePerGas

--- a/account-abstraction/rundler_maxPriorityFeePerGas.yaml
+++ b/account-abstraction/rundler_maxPriorityFeePerGas.yaml
@@ -26,19 +26,7 @@ paths:
       description: 'Returns a fee per gas that is an estimate of how much users should set as a priority fee in UOs for Rundler endpoints.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/account-abstraction/rundler_maxPriorityFeePerGas.yaml
+++ b/account-abstraction/rundler_maxPriorityFeePerGas.yaml
@@ -22,7 +22,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: rundler_maxPriorityFeePerGas
       description: 'Returns a fee per gas that is an estimate of how much users should set as a priority fee in UOs for Rundler endpoints.'
       operationId: rundler-maxPriorityFeePerGas

--- a/arbitrum/eth_chainId.yaml
+++ b/arbitrum/eth_chainId.yaml
@@ -14,5 +14,5 @@ paths:
   /{apiKey}:
     post:
       summary: eth_chainId - Arbitrum
-      operationId: eth-chainid-arbitrum
       $ref: ../ethereum/eth_chainId.yaml#/components/pathItems/path/post
+      operationId: eth-chainid-arbitrum

--- a/arbitrum/eth_createAccessList.yaml
+++ b/arbitrum/eth_createAccessList.yaml
@@ -16,19 +16,7 @@ paths:
       summary: eth_createAccessList - Arbitrum
       description: 'Arbitrum API - Creates an EIP2930 type `accessList` based on a given Transaction object. Returns list of addresses and storage keys that are read and written by the transaction (except the sender account and precompiles), plus the estimated gas consumed when the access list is added.'
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/arbitrum/eth_createAccessList.yaml
+++ b/arbitrum/eth_createAccessList.yaml
@@ -15,6 +15,7 @@ paths:
     post:
       summary: eth_createAccessList - Arbitrum
       description: 'Arbitrum API - Creates an EIP2930 type `accessList` based on a given Transaction object. Returns list of addresses and storage keys that are read and written by the transaction (except the sender account and precompiles), plus the estimated gas consumed when the access list is added.'
+      operationId: eth-createaccesslist-arbitrum
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -29,4 +30,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/eth_createAccessList
-      operationId: eth-createaccesslist-arbitrum

--- a/arbitrum/eth_feeHistory.yaml
+++ b/arbitrum/eth_feeHistory.yaml
@@ -16,6 +16,9 @@ paths:
       summary: eth_feeHistory - Arbitrum
       operationId: eth-feehistory-arbitrum
       $ref: ../ethereum/eth_feeHistory.yaml#/components/pathItems/path/post
+      responses:
+        '200':
+          description: 'Returns latest block and gas fee details.'
       x-readme:
         samples-languages:
           - curl
@@ -44,6 +47,3 @@ paths:
               ]);
 
               console.log(res);
-      responses:
-        '200':
-          description: 'Returns latest block and gas fee details.'

--- a/arbitrum/eth_getBlockByHash.yaml
+++ b/arbitrum/eth_getBlockByHash.yaml
@@ -22,19 +22,7 @@ components:
         operationId: eth-getBlockByHash-arbitrum
         description: Returns information about a block by block hash on the Arbitrum network.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/arbitrum/eth_getBlockByHash.yaml
+++ b/arbitrum/eth_getBlockByHash.yaml
@@ -13,50 +13,46 @@ servers:
         default: arb-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getBlockByHash - Arbitrum
-        operationId: eth-getBlockByHash-arbitrum
-        description: Returns information about a block by block hash on the Arbitrum network.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: eth_getBlockByHash - Arbitrum
+      description: Returns information about a block by block hash on the Arbitrum network.
+      operationId: eth-getBlockByHash-arbitrum
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getBlockByHash
+      responses:
+        '200':
+          description: 'Returns a block object with the following fields, or null when no block was found.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getBlockByHash
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                import { Alchemy, Network } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/arb_block
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              import { Alchemy, Network } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ARB_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ARB_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core
-                  .getBlock(
-                    "0x92fc42b9642023f2ee2e88094df80ce87e15d91afa812fef383e6e5cd96e2ed3"
-                  )
-                  .then(console.log);
-        responses:
-          '200':
-            description: 'Returns a block object with the following fields, or null when no block was found.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/arb_block
+              alchemy.core
+                .getBlock(
+                  "0x92fc42b9642023f2ee2e88094df80ce87e15d91afa812fef383e6e5cd96e2ed3"
+                )
+                .then(console.log);

--- a/arbitrum/eth_getBlockByNumber.yaml
+++ b/arbitrum/eth_getBlockByNumber.yaml
@@ -13,47 +13,43 @@ servers:
         default: arb-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: eth-getBlockByNumber-arbitrum
-        summary: eth_getBlockByNumber - Arbitrum
-        description: Returns information about a block by block number on the Arbitrum network.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: eth_getBlockByNumber - Arbitrum
+      description: Returns information about a block by block number on the Arbitrum network.
+      operationId: eth-getBlockByNumber-arbitrum
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getBlockByNumber
+      responses:
+        '200':
+          description: 'Returns a block object with the following fields, or null when no block was found.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getBlockByNumber
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                import { Network, Alchemy } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/arb_block
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ARB_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ARB_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core.getBlock(15221026).then(console.log);
-        responses:
-          '200':
-            description: 'Returns a block object with the following fields, or null when no block was found.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/arb_block
+              alchemy.core.getBlock(15221026).then(console.log);

--- a/arbitrum/eth_getBlockByNumber.yaml
+++ b/arbitrum/eth_getBlockByNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: eth_getBlockByNumber - Arbitrum
         description: Returns information about a block by block number on the Arbitrum network.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/arbitrum/eth_getProof.yaml
+++ b/arbitrum/eth_getProof.yaml
@@ -20,19 +20,7 @@ components:
         summary: eth_getProof - Arbitrum
         description: Returns the account and storage values of the specified account including the Merkle-proof on Arbitrum. This call can be used to verify that the data you are pulling from is not tampered with.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/arbitrum/eth_getProof.yaml
+++ b/arbitrum/eth_getProof.yaml
@@ -12,54 +12,50 @@ servers:
         default: arb-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getProof - Arbitrum
-        description: Returns the account and storage values of the specified account including the Merkle-proof on Arbitrum. This call can be used to verify that the data you are pulling from is not tampered with.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: eth_getProof - Arbitrum
+      description: Returns the account and storage values of the specified account including the Merkle-proof on Arbitrum. This call can be used to verify that the data you are pulling from is not tampered with.
+      operationId: eth-getProof-arbitrum
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getProof
+      responses:
+        '200':
+          description: 'Returns the account and storage values of the specified account.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getProof
-        responses:
-          '200':
-            description: 'Returns the account and storage values of the specified account.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getProof
-        operationId: eth-getProof-arbitrum
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                import { Network, Alchemy } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/eth_getProof
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ETH_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                // Using send method from alchemy-sdk with specific transaction details
-                const res = await alchemy.core.send('eth_getProof', [
-                  '0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842',
-                  ["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],
-                  "latest",
-                ]);
+              // Using send method from alchemy-sdk with specific transaction details
+              const res = await alchemy.core.send('eth_getProof', [
+                '0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842',
+                ["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],
+                "latest",
+              ]);
 
-                console.log(res);
+              console.log(res);

--- a/arbitrum/eth_getTransactionByBlockHashAndIndex.yaml
+++ b/arbitrum/eth_getTransactionByBlockHashAndIndex.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getTransactionByBlockHashAndIndex - Arbitrum
       description: Returns information about a transaction by block hash and transaction index position in Arbitrum network.
       operationId: eth-gettransactionbyblockhashandindex-arbitrum

--- a/arbitrum/eth_getTransactionByBlockHashAndIndex.yaml
+++ b/arbitrum/eth_getTransactionByBlockHashAndIndex.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns information about a transaction by block hash and transaction index position in Arbitrum network.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/arbitrum/eth_getTransactionByBlockHashAndIndex.yaml
+++ b/arbitrum/eth_getTransactionByBlockHashAndIndex.yaml
@@ -12,32 +12,28 @@ servers:
         default: arb-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getTransactionByBlockHashAndIndex - Arbitrum
-        description: Returns information about a transaction by block hash and transaction index position in Arbitrum network.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getTransactionByBlockHashAndIndex - Arbitrum
+      description: Returns information about a transaction by block hash and transaction index position in Arbitrum network.
+      operationId: eth-gettransactionbyblockhashandindex-arbitrum
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/eth_getTransactionByBlockHashAndIndex'
+              default:
+                params:
+                  [
+                    '0x5810f30816609df1f460b17510a1bad3745464e63d84d8eabef11c59da658d9a',
+                    '0x1',
+                  ]
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/eth_getTransactionByBlockHashAndIndex'
-                default:
-                  params:
-                    [
-                      '0x5810f30816609df1f460b17510a1bad3745464e63d84d8eabef11c59da658d9a',
-                      '0x1',
-                    ]
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: '../evm_responses.yaml#/eth_getTransactionByHash_arb'
-        operationId: eth-gettransactionbyblockhashandindex-arbitrum
+                $ref: '../evm_responses.yaml#/eth_getTransactionByHash_arb'

--- a/arbitrum/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/arbitrum/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_getTransactionByBlockNumberAndIndex - Arbitrum
       description: Returns information about a transaction by block number and transaction index position.
-      tags: []
+      operationId: eth-getTransactionByBlockNumberAndIndex-arbitrum
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -32,4 +33,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/eth_getTransactionByHash_arb
-      operationId: eth-getTransactionByBlockNumberAndIndex-arbitrum

--- a/arbitrum/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/arbitrum/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getTransactionByBlockNumberAndIndex - Arbitrum
       description: Returns information about a transaction by block number and transaction index position.
       operationId: eth-getTransactionByBlockNumberAndIndex-arbitrum

--- a/arbitrum/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/arbitrum/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns information about a transaction by block number and transaction index position.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/arbitrum/eth_getTransactionByHash.yaml
+++ b/arbitrum/eth_getTransactionByHash.yaml
@@ -21,19 +21,7 @@ components:
         description: 'Returns the information about a transaction requested by transaction hash. In the response object, `blockHash`, `blockNumber`, and `transactionIndex` are `null` when the transaction is pending.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/arbitrum/eth_getTransactionByHash.yaml
+++ b/arbitrum/eth_getTransactionByHash.yaml
@@ -17,9 +17,10 @@ components:
   pathItems:
     path:
       post:
+        tags: []
         summary: eth_getTransactionByHash - Arbitrum
         description: 'Returns the information about a transaction requested by transaction hash. In the response object, `blockHash`, `blockNumber`, and `transactionIndex` are `null` when the transaction is pending.'
-        tags: []
+        operationId: eth-getTransactionByHash-arbitrum
         parameters:
           - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
@@ -32,6 +33,13 @@ components:
                     [
                       '0x2d6da6ea7d7d7d1ca72576dc457a2b6f59fb798566fb97492b3f2835b0a59178',
                     ]
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: ../evm_responses.yaml#/eth_getTransactionByHash_arb
         x-readme:
           samples-languages:
             - curl
@@ -57,11 +65,3 @@ components:
                     "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"
                   )
                   .then(console.log);
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getTransactionByHash_arb
-        operationId: eth-getTransactionByHash-arbitrum

--- a/arbitrum/eth_getTransactionReceipt.yaml
+++ b/arbitrum/eth_getTransactionReceipt.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getTransactionReceipt - Arbitrum
       description: Returns the receipt of a transaction by transaction hash.
       operationId: eth-getTransactionReceipt-arbitrum

--- a/arbitrum/eth_getTransactionReceipt.yaml
+++ b/arbitrum/eth_getTransactionReceipt.yaml
@@ -12,56 +12,52 @@ servers:
         default: arb-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getTransactionReceipt - Arbitrum
-        description: Returns the receipt of a transaction by transaction hash.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getTransactionReceipt - Arbitrum
+      description: Returns the receipt of a transaction by transaction hash.
+      operationId: eth-getTransactionReceipt-arbitrum
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getTransactionReceipt
+              default:
+                params:
+                  [
+                    '0x0f332c74582e9277344c33ad989b1a1854a6cd78710b262e1165b52c26afec74',
+                  ]
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getTransactionReceipt
-                default:
-                  params:
-                    [
-                      '0x0f332c74582e9277344c33ad989b1a1854a6cd78710b262e1165b52c26afec74',
-                    ]
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                import { Network, Alchemy } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/eth_getTransactionReceipt_arb
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ARB_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ARB_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core
-                  .getTransactionReceipt(
-                    "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"
-                  )
-                  .then(console.log);
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getTransactionReceipt_arb
-        operationId: eth-getTransactionReceipt-arbitrum
+              alchemy.core
+                .getTransactionReceipt(
+                  "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"
+                )
+                .then(console.log);

--- a/arbitrum/eth_getTransactionReceipt.yaml
+++ b/arbitrum/eth_getTransactionReceipt.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns the receipt of a transaction by transaction hash.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/arbitrum/eth_maxPriorityFeePerGas.yaml
+++ b/arbitrum/eth_maxPriorityFeePerGas.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_maxPriorityFeePerGas - Arbitrum
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       operationId: eth-maxpriorityfeepergas-arbitrum

--- a/arbitrum/eth_maxPriorityFeePerGas.yaml
+++ b/arbitrum/eth_maxPriorityFeePerGas.yaml
@@ -17,19 +17,7 @@ paths:
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/arbitrum/eth_maxPriorityFeePerGas.yaml
+++ b/arbitrum/eth_maxPriorityFeePerGas.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_maxPriorityFeePerGas - Arbitrum
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
-      tags: []
+      operationId: eth-maxpriorityfeepergas-arbitrum
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/string_result_response
-      operationId: eth-maxpriorityfeepergas-arbitrum

--- a/astar/eth_maxPriorityFeePerGas.yaml
+++ b/astar/eth_maxPriorityFeePerGas.yaml
@@ -7,7 +7,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_maxPriorityFeePerGas - Astar
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       operationId: eth-maxPriorityFeePerGas-astar

--- a/astar/eth_maxPriorityFeePerGas.yaml
+++ b/astar/eth_maxPriorityFeePerGas.yaml
@@ -11,19 +11,7 @@ paths:
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/astar/eth_maxPriorityFeePerGas.yaml
+++ b/astar/eth_maxPriorityFeePerGas.yaml
@@ -7,9 +7,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_maxPriorityFeePerGas - Astar
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
-      tags: []
+      operationId: eth-maxPriorityFeePerGas-astar
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -24,4 +25,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/string_result_response
-      operationId: eth-maxPriorityFeePerGas-astar

--- a/base/eth_feeHistory.yaml
+++ b/base/eth_feeHistory.yaml
@@ -12,31 +12,27 @@ servers:
         default: base-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_feeHistory - Base
-        description: Returns a collection of historical gas information.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_feeHistory - Base
+      description: Returns a collection of historical gas information.
+      operationId: eth-feeHistory-base
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_feeHistory
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_feeHistory
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_feeHistory
-        operationId: eth-feeHistory-base
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
+                $ref: ../evm_responses.yaml#/eth_feeHistory
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/base/eth_feeHistory.yaml
+++ b/base/eth_feeHistory.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_feeHistory - Base
       description: Returns a collection of historical gas information.
       operationId: eth-feeHistory-base

--- a/base/eth_feeHistory.yaml
+++ b/base/eth_feeHistory.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns a collection of historical gas information.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/base/eth_getBlockByNumber.yaml
+++ b/base/eth_getBlockByNumber.yaml
@@ -16,11 +16,6 @@ paths:
       summary: eth_getBlockByNumber - Base
       $ref: ../ethereum/eth_getBlockByNumber.yaml#/components/pathItems/path/post
       operationId: eth-getblockbynumber-base
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
       responses:
         '200':
           description: 'Returns a block object with the following fields, or null when no block was found.'
@@ -104,3 +99,8 @@ paths:
                                 items:
                                   type: string
                                 description: Array of uncle hashes.
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/base/eth_getProof.yaml
+++ b/base/eth_getProof.yaml
@@ -20,19 +20,7 @@ components:
         summary: eth_getProof - Base
         description: Returns the account and storage values of the specified account including the Merkle-proof on Base. This call can be used to verify that the data you are pulling from is not tampered with.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/base/eth_getProof.yaml
+++ b/base/eth_getProof.yaml
@@ -12,31 +12,27 @@ servers:
         default: base-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getProof - Base
-        description: Returns the account and storage values of the specified account including the Merkle-proof on Base. This call can be used to verify that the data you are pulling from is not tampered with.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: eth_getProof - Base
+      description: Returns the account and storage values of the specified account including the Merkle-proof on Base. This call can be used to verify that the data you are pulling from is not tampered with.
+      operationId: eth-getProof-base
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getProof
+      responses:
+        '200':
+          description: 'Returns the account and storage values of the specified account.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getProof
-        responses:
-          '200':
-            description: 'Returns the account and storage values of the specified account.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getProof
-        operationId: eth-getProof-base
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
+                $ref: ../evm_responses.yaml#/eth_getProof
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/base/eth_maxPriorityFeePerGas.yaml
+++ b/base/eth_maxPriorityFeePerGas.yaml
@@ -17,19 +17,7 @@ paths:
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/base/eth_maxPriorityFeePerGas.yaml
+++ b/base/eth_maxPriorityFeePerGas.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_maxPriorityFeePerGas - Base
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
-      tags: []
+      operationId: eth-maxpriorityfeepergas-base
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/string_result_response
-      operationId: eth-maxpriorityfeepergas-base

--- a/base/eth_maxPriorityFeePerGas.yaml
+++ b/base/eth_maxPriorityFeePerGas.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_maxPriorityFeePerGas - Base
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       operationId: eth-maxpriorityfeepergas-base

--- a/base/eth_syncing.yaml
+++ b/base/eth_syncing.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_syncing - Base
       description: Returns a list of addresses owned by client.
       operationId: eth-syncing-base

--- a/base/eth_syncing.yaml
+++ b/base/eth_syncing.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns a list of addresses owned by client.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         description: Accepts nothing.
         content:

--- a/base/eth_syncing.yaml
+++ b/base/eth_syncing.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_syncing - Base
       description: Returns a list of addresses owned by client.
-      tags: []
+      operationId: eth-syncing-base
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -31,4 +32,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/eth_syncing
-      operationId: eth-syncing-base

--- a/components/parameters.yaml
+++ b/components/parameters.yaml
@@ -3,7 +3,13 @@ ApiKey:
   name: apiKey
   in: path
   # TODO: should we link to /signup directly?
-  description: For higher throughput, **[create your own API key](https://alchemy.com/?a=docs-demo)**.
+  description: |
+    <style>
+      .custom-style {
+        color: #048FF4;
+      }
+    </style>
+    For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
   required: true
   schema:
     type: string

--- a/debug/debug_traceBlockByHash.yaml
+++ b/debug/debug_traceBlockByHash.yaml
@@ -19,7 +19,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: debug_traceBlockByHash
       description: Replays the block that is already present in the database.
       operationId: debug-traceblockbyhash

--- a/debug/debug_traceBlockByHash.yaml
+++ b/debug/debug_traceBlockByHash.yaml
@@ -23,19 +23,7 @@ paths:
       description: Replays the block that is already present in the database.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/debug/debug_traceBlockByHash.yaml
+++ b/debug/debug_traceBlockByHash.yaml
@@ -19,9 +19,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: debug_traceBlockByHash
       description: Replays the block that is already present in the database.
-      tags: []
+      operationId: debug-traceblockbyhash
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -29,6 +30,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/debug_traceBlockByHash
+      responses:
+        '200':
+          description: 'Returns - array of block traces'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/debug_traceBlockByHash
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -74,11 +82,3 @@ paths:
               -H "Content-Type: application/json" \
               --data '{"method":"debug_traceBlockByHash","params":["0x97b49e43632ac70c46b4003434058b18db0ad809617bd29f3448d46ca9085576", {"tracer": "callTracer"}],"id":1,"jsonrpc":"2.0"}'
             name: cURL
-      responses:
-        '200':
-          description: 'Returns - array of block traces'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/debug_traceBlockByHash
-      operationId: debug-traceblockbyhash

--- a/debug/debug_traceBlockByNumber.yaml
+++ b/debug/debug_traceBlockByNumber.yaml
@@ -19,11 +19,24 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: debug_traceBlockByNumber
       description: Replays the block that is already present in the database.
-      tags: []
+      operationId: debug-traceblockbynumber
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/debug_traceBlockByNumber
+      responses:
+        '200':
+          description: 'Returns - array of block traces'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/debug_traceBlockByNumber
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -69,16 +82,3 @@ paths:
               -H "Content-Type: application/json" \
               --data '{"method":"debug_traceBlockByNumber","params":["0xccde12", {"tracer": "callTracer"}],"id":1,"jsonrpc":"2.0"}'
             name: cURL
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: ../evm_body.yaml#/debug_traceBlockByNumber
-      responses:
-        '200':
-          description: 'Returns - array of block traces'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/debug_traceBlockByNumber
-      operationId: debug-traceblockbynumber

--- a/debug/debug_traceBlockByNumber.yaml
+++ b/debug/debug_traceBlockByNumber.yaml
@@ -19,7 +19,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: debug_traceBlockByNumber
       description: Replays the block that is already present in the database.
       operationId: debug-traceblockbynumber

--- a/debug/debug_traceBlockByNumber.yaml
+++ b/debug/debug_traceBlockByNumber.yaml
@@ -23,19 +23,7 @@ paths:
       description: Replays the block that is already present in the database.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       x-readme:
         explorer-enabled: false
         samples-languages:

--- a/debug/debug_traceCall.yaml
+++ b/debug/debug_traceCall.yaml
@@ -19,7 +19,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: debug_traceCall
       description: Runs an eth_call within the context of the given block execution using the final state of parent block as the base.
       operationId: debug-tracecall

--- a/debug/debug_traceCall.yaml
+++ b/debug/debug_traceCall.yaml
@@ -23,19 +23,7 @@ paths:
       description: Runs an eth_call within the context of the given block execution using the final state of parent block as the base.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/debug/debug_traceCall.yaml
+++ b/debug/debug_traceCall.yaml
@@ -19,9 +19,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: debug_traceCall
       description: Runs an eth_call within the context of the given block execution using the final state of parent block as the base.
-      tags: []
+      operationId: debug-tracecall
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -29,6 +30,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/debug_traceCall
+      responses:
+        '200':
+          description: 'Returns - Array of block traces'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/debug_traceCall
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -78,11 +86,3 @@ paths:
               -H "Content-Type: application/json" \
               --data '{"method":"debug_traceCall","params":[{"from":null,"to":"0x6b175474e89094c44da98b954eedeac495271d0f","data":"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE"}, "latest"],"id":1,"jsonrpc":"2.0"}'
             name: cURL
-      responses:
-        '200':
-          description: 'Returns - Array of block traces'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/debug_traceCall
-      operationId: debug-tracecall

--- a/debug/debug_traceTransaction.yaml
+++ b/debug/debug_traceTransaction.yaml
@@ -19,7 +19,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: debug_traceTransaction
       description: Attempts to run the transaction in the exact same manner as it was executed on the network. It will replay any transaction that may have been executed prior to this one before it and will then attempt to execute the transaction that corresponds to the given hash.
       operationId: debug-tracetransaction

--- a/debug/debug_traceTransaction.yaml
+++ b/debug/debug_traceTransaction.yaml
@@ -23,19 +23,7 @@ paths:
       description: Attempts to run the transaction in the exact same manner as it was executed on the network. It will replay any transaction that may have been executed prior to this one before it and will then attempt to execute the transaction that corresponds to the given hash.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/debug/debug_traceTransaction.yaml
+++ b/debug/debug_traceTransaction.yaml
@@ -19,9 +19,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: debug_traceTransaction
       description: Attempts to run the transaction in the exact same manner as it was executed on the network. It will replay any transaction that may have been executed prior to this one before it and will then attempt to execute the transaction that corresponds to the given hash.
-      tags: []
+      operationId: debug-tracetransaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -29,6 +30,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/debug_traceTransaction
+      responses:
+        '200':
+          description: 'Returns - transaction trace'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/debug_traceTransaction
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -75,11 +83,3 @@ paths:
               -H "Content-Type: application/json" \
               --data '{"method":"debug_traceTransaction","params":["0x9e63085271890a141297039b3b711913699f1ee4db1acb667ad7ce304772036b", {"tracer": "callTracer"}], "id":1,"jsonrpc":"2.0"}'
             name: cURL
-      responses:
-        '200':
-          description: 'Returns - transaction trace'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/debug_traceTransaction
-      operationId: debug-tracetransaction

--- a/ethereum/eth_accounts.yaml
+++ b/ethereum/eth_accounts.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns a list of addresses owned by client. Since Alchemy does not store keys, this will always return empty.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_blockNumber.yaml
+++ b/ethereum/eth_blockNumber.yaml
@@ -23,19 +23,7 @@ components:
         operationId: eth-blocknumber
         description: Returns the number of the most recent block.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts nothing.
           content:

--- a/ethereum/eth_call.yaml
+++ b/ethereum/eth_call.yaml
@@ -23,19 +23,7 @@ components:
         summary: eth_call - Ethereum
         description: Executes a new message call immediately without creating a transaction on the block chain.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts the transaction call object, state overrides and the block number / block hash / block tag to execute the call on.
           content:

--- a/ethereum/eth_chainId.yaml
+++ b/ethereum/eth_chainId.yaml
@@ -22,19 +22,7 @@ components:
         description: 'Returns the currently configured chain ID, a value used in replay-protected transaction signing as introduced by EIP-155.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_createAccessList.yaml
+++ b/ethereum/eth_createAccessList.yaml
@@ -21,19 +21,7 @@ components:
         summary: eth_createAccessList - Ethereum
         description: 'Ethereum API - Creates an EIP2930 type `accessList` based on a given Transaction object. Returns list of addresses and storage keys that are read and written by the transaction (except the sender account and precompiles), plus the estimated gas consumed when the access list is added.'
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_estimateGas.yaml
+++ b/ethereum/eth_estimateGas.yaml
@@ -22,19 +22,7 @@ components:
         description: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_feeHistory.yaml
+++ b/ethereum/eth_feeHistory.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns a collection of historical gas information.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_gasPrice.yaml
+++ b/ethereum/eth_gasPrice.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the current price per gas in wei.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getBalance.yaml
+++ b/ethereum/eth_getBalance.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the balance of the account of a given address.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getBlockByHash.yaml
+++ b/ethereum/eth_getBlockByHash.yaml
@@ -23,19 +23,7 @@ components:
         summary: eth_getBlockByHash - Ethereum
         description: Returns information about a block by block hash.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getBlockByNumber.yaml
+++ b/ethereum/eth_getBlockByNumber.yaml
@@ -23,19 +23,7 @@ components:
         summary: eth_getBlockByNumber - Ethereum
         description: Returns information about a block by block number.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getBlockReceipts.yaml
+++ b/ethereum/eth_getBlockReceipts.yaml
@@ -18,19 +18,7 @@ paths:
       description: Get all transaction receipts for a given block on Ethereum.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/ethereum/eth_getBlockReceipts.yaml
+++ b/ethereum/eth_getBlockReceipts.yaml
@@ -16,7 +16,6 @@ paths:
     post:
       summary: eth_getBlockReceipts - Ethereum
       description: Get all transaction receipts for a given block on Ethereum.
-      tags: []
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:

--- a/ethereum/eth_getBlockTransactionCountByHash.yaml
+++ b/ethereum/eth_getBlockTransactionCountByHash.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the number of transactions in a block matching the given block hash.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getBlockTransactionCountByNumber.yaml
+++ b/ethereum/eth_getBlockTransactionCountByNumber.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the number of transactions in a block matching the given block number.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getCode.yaml
+++ b/ethereum/eth_getCode.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns code at a given address.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getFilterChanges.yaml
+++ b/ethereum/eth_getFilterChanges.yaml
@@ -23,19 +23,7 @@ components:
         description: 'Polling method for a filter, which returns an array of logs which occurred since last poll.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getFilterLogs.yaml
+++ b/ethereum/eth_getFilterLogs.yaml
@@ -23,19 +23,7 @@ components:
         description: Returns an array of all logs matching filter with given id. Can compute the same results with an eth_getLogs call.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getLogs.yaml
+++ b/ethereum/eth_getLogs.yaml
@@ -24,19 +24,7 @@ components:
         description: |
           Returns an array of all logs matching a given filter object.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getProof.yaml
+++ b/ethereum/eth_getProof.yaml
@@ -21,19 +21,7 @@ components:
         summary: eth_getProof - Ethereum
         description: Returns the account and storage values of the specified account including the Merkle-proof. This call can be used to verify that the data you are pulling from is not tampered with.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getStorageAt.yaml
+++ b/ethereum/eth_getStorageAt.yaml
@@ -22,19 +22,7 @@ components:
         description: "Returns the value from a storage position at a given address, or in other words, returns the state of the contract's storage, which may not be exposed via the contract's methods."
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getTransactionByBlockHashAndIndex.yaml
+++ b/ethereum/eth_getTransactionByBlockHashAndIndex.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns information about a transaction by block hash and transaction index position.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/ethereum/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns information about a transaction by block number and transaction index position.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getTransactionByHash.yaml
+++ b/ethereum/eth_getTransactionByHash.yaml
@@ -22,19 +22,7 @@ components:
         description: 'Returns the information about a transaction requested by transaction hash. In the response object, `blockHash`, `blockNumber`, and `transactionIndex` are `null` when the transaction is pending.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getTransactionCount.yaml
+++ b/ethereum/eth_getTransactionCount.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the number of transactions sent from an address.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getTransactionReceipt.yaml
+++ b/ethereum/eth_getTransactionReceipt.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the receipt of a transaction by transaction hash.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getUncleByBlockHashAndIndex.yaml
+++ b/ethereum/eth_getUncleByBlockHashAndIndex.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns information about an uncle of a block by hash and uncle index position.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getUncleByBlockNumberAndIndex.yaml
+++ b/ethereum/eth_getUncleByBlockNumberAndIndex.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns information about an uncle of a block by number and uncle index position.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getUncleCountByBlockHash.yaml
+++ b/ethereum/eth_getUncleCountByBlockHash.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the number of uncles in a block matching the given block hash.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_getUncleCountByBlockNumber.yaml
+++ b/ethereum/eth_getUncleCountByBlockNumber.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the number of uncles in a block matching the given block number.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_maxPriorityFeePerGas.yaml
+++ b/ethereum/eth_maxPriorityFeePerGas.yaml
@@ -16,7 +16,6 @@ paths:
     post:
       summary: eth_maxPriorityFeePerGas - Ethereum
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
-      tags: []
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:

--- a/ethereum/eth_maxPriorityFeePerGas.yaml
+++ b/ethereum/eth_maxPriorityFeePerGas.yaml
@@ -18,19 +18,7 @@ paths:
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/ethereum/eth_newBlockFilter.yaml
+++ b/ethereum/eth_newBlockFilter.yaml
@@ -23,19 +23,7 @@ components:
         description: 'Creates a filter in the node, to notify when a new block arrives.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts nothing.
           content:

--- a/ethereum/eth_newFilter.yaml
+++ b/ethereum/eth_newFilter.yaml
@@ -23,19 +23,7 @@ components:
         description: 'Creates a filter object, based on filter options, to notify when the state changes (logs).'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_newPendingTransactionFilter.yaml
+++ b/ethereum/eth_newPendingTransactionFilter.yaml
@@ -23,19 +23,7 @@ components:
         description: 'Creates a filter in the node, to notify when new pending transactions arrive. To check if the state has changed, call eth_getFilterChanges.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts nothing.
           content:

--- a/ethereum/eth_protocolVersion.yaml
+++ b/ethereum/eth_protocolVersion.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the current ethereum protocol version.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_sendRawTransaction.yaml
+++ b/ethereum/eth_sendRawTransaction.yaml
@@ -22,19 +22,7 @@ components:
         description: Creates a new message call transaction or a contract creation for signed transactions.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/eth_uninstallFilter.yaml
+++ b/ethereum/eth_uninstallFilter.yaml
@@ -23,19 +23,7 @@ components:
         description: 'Uninstalls a filter with given id. Should always be called when watch is no longer needed. Additionally, Filters timeout when they aren’t requested with eth_getFilterChangesfor a period of time.'
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/net_listening.yaml
+++ b/ethereum/net_listening.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns true if client is actively listening for network connections.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/net_version.yaml
+++ b/ethereum/net_version.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the current network id.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/web3_clientVersion.yaml
+++ b/ethereum/web3_clientVersion.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns the current client version.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/ethereum/web3_sha3.yaml
+++ b/ethereum/web3_sha3.yaml
@@ -22,19 +22,7 @@ components:
         description: Returns Keccak-256 (not the standardized SHA3-256) of the given data.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -25,9 +25,10 @@ paths:
   ##
   '/v2/{apiKey}/getNFTs':
     get:
+      tags: ['Ownership & Token Gating']
       summary: getNFTs
       description: Gets all NFTs currently owned by a given address.
-      tags: ['Ownership & Token Gating']
+      operationId: getNFTs
       parameters:
         - $ref: '#/components/schemas/owner'
         - $ref: '#/components/schemas/contractAddresses'
@@ -40,30 +41,6 @@ paths:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/pageKey'
         - $ref: '#/components/schemas/pageSize'
-      x-readme:
-        samples-languages:
-          - curl
-          - javascript
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Setup: npm install alchemy-sdk
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              import { Network, Alchemy } from "alchemy-sdk";
-
-              // Optional Config object, but defaults to demo api-key and eth-mainnet.
-              const settings = {
-                apiKey: demo, // Replace with your Alchemy API Key.
-                network: Network.ETH_MAINNET, // Replace with your network.
-
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              // Print all NFTs returned in the response:
-              alchemy.nft.getNftsForOwner("vitalik.eth").then(console.log);
       responses:
         '200':
           description: 'Returns the list of all NFTs owned by the given address and satisfying the given input parameters.'
@@ -92,12 +69,36 @@ paths:
                   $ref: '#/components/schemas/withContractFiltering_response'
                 withPagination:
                   $ref: '#/components/schemas/withPagination_response'
-      operationId: getNFTs
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
+
+              // Optional Config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: demo, // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              // Print all NFTs returned in the response:
+              alchemy.nft.getNftsForOwner("vitalik.eth").then(console.log);
   '/v2/{apiKey}/getNFTMetadata':
     get:
+      tags: ['NFT Metadata Access']
       summary: getNFTMetadata
       description: Gets the metadata associated with a given NFT.
-      tags: ['NFT Metadata Access']
+      operationId: getNFTMetadata
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -107,6 +108,13 @@ paths:
         - $ref: '#/components/schemas/tokenType'
         - $ref: '#/components/schemas/tokenUriTimeoutInMs'
         - $ref: '#/components/schemas/refreshCache'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ownedNFT'
       x-readme:
         samples-languages:
           - curl
@@ -133,19 +141,12 @@ paths:
                 "0x5180db8F5c931aaE63c74266b211F580155ecac8",
                 "1590"
               ).then(console.log);
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ownedNFT'
-      operationId: getNFTMetadata
   '/v2/{apiKey}/getNFTMetadataBatch':
     post:
+      tags: ['NFT Metadata Access']
       summary: getNFTMetadataBatch
       description: Gets the metadata associated with up to 100 given NFT contracts.
-      tags: ['NFT Metadata Access']
+      operationId: getNFTMetadataBatch
       parameters:
         - $ref: '#/components/schemas/apiKey'
       requestBody:
@@ -173,6 +174,15 @@ paths:
                   $ref: '#/components/schemas/refreshCache'
                   type: boolean
                   default: false
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ownedNFT'
       x-readme:
         samples-languages:
           - curl
@@ -199,25 +209,29 @@ paths:
                 "0x5180db8F5c931aaE63c74266b211F580155ecac8",
                 "1590"
               ).then(console.log);
+  '/v2/{apiKey}/getContractMetadata':
+    get:
+      tags: ['NFT Metadata Access']
+      summary: getContractMetadata
+      description: Queries NFT high-level collection/contract level information.
+      operationId: getContractMetadata
+      parameters:
+        - $ref: '#/components/schemas/apiKey'
+        - $ref: '#/components/schemas/contractAddress'
+          required: true
       responses:
         '200':
           description: ''
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ownedNFT'
-      operationId: getNFTMetadataBatch
-  '/v2/{apiKey}/getContractMetadata':
-    get:
-      summary: getContractMetadata
-      description: Queries NFT high-level collection/contract level information.
-      tags: ['NFT Metadata Access']
-      parameters:
-        - $ref: '#/components/schemas/apiKey'
-        - $ref: '#/components/schemas/contractAddress'
-          required: true
+                type: object
+                properties:
+                  address:
+                    type: string
+                    description: 'String - Contract address for the queried NFT collection'
+                  contractMetadata:
+                    $ref: '#/components/schemas/contractMetadata'
       x-readme:
         samples-languages:
           - curl
@@ -242,20 +256,7 @@ paths:
               alchemy.nft
                 .getContractMetadata("0x61fce80d72363b731425c3a2a46a1a5fed9814b2")
                 .then(console.log);
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  address:
-                    type: string
-                    description: 'String - Contract address for the queried NFT collection'
-                  contractMetadata:
-                    $ref: '#/components/schemas/contractMetadata'
-      operationId: getContractMetadata
+
   '/v2/{apiKey}/getContractMetadataBatch':
     post:
       summary: getContractMetadataBatch

--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -7,34 +7,13 @@ servers:
 paths:
   /graphql/variables/{variable}:
     get:
+      tags: ['Custom Webhook API Methods']
       summary: Read Variable Elements
       description: This endpoint allows you to read the values within a Custom Webhook variable
-      tags: ['Custom Webhook API Methods']
+      operationId: read-custom-webhook-variable
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
         - $ref: '#/components/schemas/variable'
-      x-readme:
-        samples-languages:
-          - curl
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Setup: npm install alchemy-sdk
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              import { Alchemy, Network } from "alchemy-sdk";
-
-              // authToken is required to use Notify APIs. Found on the top right corner of
-              // https://dashboard.alchemy.com/notify.
-              const settings = {
-                authToken: "your-notify-auth-token",
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              alchemy.notify.getAllWebhooks().then(console.log);
       responses:
         '200':
           description: OK- Successful query of Custom Webhook variable
@@ -48,11 +27,33 @@ paths:
           description: Not found- The requested resource could not be found
         '500':
           description: Internal Server Error- Try again
-      operationId: read-custom-webhook-variable
+      x-readme:
+        samples-languages:
+          - curl
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Alchemy, Network } from "alchemy-sdk";
+
+              // authToken is required to use Notify APIs. Found on the top right corner of
+              // https://dashboard.alchemy.com/notify.
+              const settings = {
+                authToken: "your-notify-auth-token",
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              alchemy.notify.getAllWebhooks().then(console.log);
     post:
+      tags: ['Custom Webhook API Methods']
       summary: Create a Variable
       description: This endpoint allows you to create a variable that can be inserted into a Custom Webhook GraphQL statement
-      tags: ['Custom Webhook API Methods']
+      operationId: create-custom-webhook-variable
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
         - $ref: '#/components/schemas/variable'
@@ -61,28 +62,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/create_custom_webhook'
-      x-readme:
-        samples-languages:
-          - curl
-          - python
-        code-samples:
-          - language: javascript
-            name: Alchemy SDK
-            code: |
-              // Setup: npm install alchemy-sdk
-              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-              import { Alchemy, Network } from "alchemy-sdk";
-
-              // authToken is required to use Notify APIs. Found on the top right corner of
-              // https://dashboard.alchemy.com/notify.
-              const settings = {
-                authToken: "your-notify-auth-token",
-                network: Network.ETH_MAINNET, // Replace with your network.
-              };
-
-              const alchemy = new Alchemy(settings);
-
-              alchemy.notify.getAllWebhooks().then(console.log);
       responses:
         '201':
           description: OK- Successful PUT creation of a Custom Webhook variable
@@ -90,14 +69,6 @@ paths:
           description: Bad Request- The server cannot understand the request sent by the client, due to a malformed syntax or missing information
         '500':
           description: Internal Server Error- Try again
-      operationId: create-custom-webhook-variable
-    delete:
-      summary: Delete a Variable
-      description: This endpoint allows you to delete a Custom Webhook variable
-      tags: ['Custom Webhook API Methods']
-      parameters:
-        - $ref: '#/components/schemas/X-Alchemy-Token'
-        - $ref: '#/components/schemas/variable'
       x-readme:
         samples-languages:
           - curl
@@ -120,6 +91,14 @@ paths:
               const alchemy = new Alchemy(settings);
 
               alchemy.notify.getAllWebhooks().then(console.log);
+    delete:
+      tags: ['Custom Webhook API Methods']
+      summary: Delete a Variable
+      description: This endpoint allows you to delete a Custom Webhook variable
+      operationId: delete-custom-webhook-variable
+      parameters:
+        - $ref: '#/components/schemas/X-Alchemy-Token'
+        - $ref: '#/components/schemas/variable'
       responses:
         '201':
           description: OK- Successful deletion of a Custom Webhook variable
@@ -127,11 +106,33 @@ paths:
           description: Not found- The requested resource could not be found
         '500':
           description: Internal Server Error- Try again
-      operationId: delete-custom-webhook-variable
+      x-readme:
+        samples-languages:
+          - curl
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Alchemy, Network } from "alchemy-sdk";
+
+              // authToken is required to use Notify APIs. Found on the top right corner of
+              // https://dashboard.alchemy.com/notify.
+              const settings = {
+                authToken: "your-notify-auth-token",
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+
+              const alchemy = new Alchemy(settings);
+
+              alchemy.notify.getAllWebhooks().then(console.log);
     patch:
+      tags: ['Custom Webhook API Methods']
       summary: Update a Variable
       description: 'Add and remove elements within a Custom Webhook variable'
-      tags: ['Custom Webhook API Methods']
+      operationId: update-custom-webhook-variable
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
         - $ref: '#/components/schemas/variable'
@@ -140,6 +141,15 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/update_custom_webhook_variable'
+      responses:
+        '200':
+          description: OK- Successful update to Custom Webhook variable
+        '400':
+          description: Bad Request- The server cannot understand the request sent by the client, due to a malformed syntax or missing information
+        '401':
+          description: Unauthorized- missing or invalid authentication credentials
+        '500':
+          description: Internal Server Error- Try again
       x-readme:
         samples-languages:
           - curl
@@ -176,23 +186,23 @@ paths:
                   },
                 ],
               });
-      responses:
-        '200':
-          description: OK- Successful update to Custom Webhook variable
-        '400':
-          description: Bad Request- The server cannot understand the request sent by the client, due to a malformed syntax or missing information
-        '401':
-          description: Unauthorized- missing or invalid authentication credentials
-        '500':
-          description: Internal Server Error- Try again
-      operationId: update-custom-webhook-variable
   /team-webhooks:
     get:
+      tags: ['Notify API Methods']
       summary: Get all webhooks
       description: This endpoint allows you to get all webhooks on your team.
-      tags: ['Notify API Methods']
+      operationId: team-webhooks
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
+      responses:
+        '200':
+          description: Returns list of webhook objects.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/webhook_object_response'
       x-readme:
         samples-languages:
           - curl
@@ -216,26 +226,26 @@ paths:
               const alchemy = new Alchemy(settings);
 
               alchemy.notify.getAllWebhooks().then(console.log);
-      responses:
-        '200':
-          description: Returns list of webhook objects.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/webhook_object_response'
-      operationId: team-webhooks
   /webhook-addresses:
     get:
+      tags: ['Notify API Methods']
       summary: Get all addresses for an Address Activity webhook
       description: Paginated endpoint to list all of the addresses a given Address Activity webhook is subscribed to.
-      tags: ['Notify API Methods']
+      operationId: webhook-addresses
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
         - $ref: '#/components/schemas/webhook_id'
         - $ref: '#/components/schemas/limit'
         - $ref: '#/components/schemas/after'
+      responses:
+        '200':
+          description: 'List of addresses and pagination info.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/webhook_addresses_response'
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -267,21 +277,12 @@ paths:
                 hooks.webhooks[3],
                 { limit: 3, pageKey: 1 }
               );
-      responses:
-        '200':
-          description: 'List of addresses and pagination info.'
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/webhook_addresses_response'
-      operationId: webhook-addresses
   /create-webhook:
     post:
+      tags: ['Notify API Methods']
       summary: Create webhook
       description: 'This endpoint allows you to create a webhook.'
-      tags: ['Notify API Methods']
+      operationId: create-webhook
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
       requestBody:
@@ -289,6 +290,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/create_webhook'
+      responses:
+        '200':
+          description: 'Returns webhook creation data.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_webhook_response'
       x-readme:
         samples-languages:
           - curl
@@ -345,21 +353,14 @@ paths:
                   network: Network.ETH_MAINNET,
                 }
               );
-      responses:
-        '200':
-          description: 'Returns webhook creation data.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/create_webhook_response'
-      operationId: create-webhook
   /update-webhook-addresses:
     patch:
+      tags: ['Notify API Methods']
       summary: Add and remove webhook addresses
       description: |
         Add or remove addresses from a specific webhook.
         *This webhook endpoint is idempotent, meaning that identical requests can be made once or several times in a row with the same effect*
-      tags: ['Notify API Methods']
+      operationId: update-webhook-addresses
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
       requestBody:
@@ -367,6 +368,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/update_webhook_addresses'
+      responses:
+        '200':
+          description: 'Returns empty object.'
+          content:
+            application/json:
+              schema:
+                type: object
       x-readme:
         samples-languages:
           - curl
@@ -397,18 +405,11 @@ paths:
                 ],
                 removeAddresses: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96043"],
               });
-      responses:
-        '200':
-          description: 'Returns empty object.'
-          content:
-            application/json:
-              schema:
-                type: object
-      operationId: update-webhook-addresses
     put:
+      tags: ['Notify API Methods']
       summary: Replace webhook addresses
       description: 'Replace entire list of addresses tracked in a given webhook.'
-      tags: ['Notify API Methods']
+      operationId: replace-webhook-addresses
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
       requestBody:
@@ -416,6 +417,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/replace_webhook_addresses'
+      responses:
+        '200':
+          description: 'Returns empty object.'
+          content:
+            application/json:
+              schema:
+                type: object
       x-readme:
         samples-languages:
           - curl
@@ -442,19 +450,12 @@ paths:
               await alchemy.notify.updateWebhook("wh_qv16bt12wbj9kax4", {
                 newAddresses: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96010"],
               });
-      responses:
-        '200':
-          description: 'Returns empty object.'
-          content:
-            application/json:
-              schema:
-                type: object
-      operationId: replace-webhook-addresses
   /update-webhook:
     put:
+      tags: ['Notify API Methods']
       summary: Update webhook status
       description: 'Allows you to set status of webhooks to active or inactive.'
-      tags: ['Notify API Methods']
+      operationId: update-webhook
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
       requestBody:
@@ -462,6 +463,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/update_webhook'
+      responses:
+        '200':
+          description: 'Returns updated webhook status.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/update_webhook_response'
       x-readme:
         samples-languages:
           - curl
@@ -485,19 +493,12 @@ paths:
               const alchemy = new Alchemy(settings);
 
               await alchemy.notify.updateWebhook("wh_qv16bt12wbj9kax4", { isActive: false });
-      responses:
-        '200':
-          description: 'Returns updated webhook status.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/update_webhook_response'
-      operationId: update-webhook
   /update-webhook-nft-filters:
     patch:
+      tags: ['Notify API Methods']
       summary: Update webhook NFT filters
       description: 'Add and remove webhook NFT filters'
-      tags: ['Notify API Methods']
+      operationId: update-webhook-nft-filters
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
       requestBody:
@@ -505,6 +506,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/update_webhook_nft_filters'
+      responses:
+        '200':
+          description: 'Returns empty object.'
+          content:
+            application/json:
+              schema:
+                type: object
       x-readme:
         samples-languages:
           - curl
@@ -542,19 +550,12 @@ paths:
                   },
                 ],
               });
-      responses:
-        '200':
-          description: 'Returns empty object.'
-          content:
-            application/json:
-              schema:
-                type: object
-      operationId: update-webhook-nft-filters
   /update-webhook-nft-metadata-filters:
     patch:
+      tags: ['Notify API Methods']
       summary: Update NFT metadata webhook filters
       description: 'Add and remove NFT metadata webhook filters'
-      tags: ['Notify API Methods']
+      operationId: update-webhook-nft-metadata-filters
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
       requestBody:
@@ -569,18 +570,27 @@ paths:
             application/json:
               schema:
                 type: object
-      operationId: update-webhook-nft-metadata-filters
 
   /webhook-nft-filters:
     get:
+      tags: ['Notify API Methods']
       summary: Get all webhook NFT filters
       description: Paginated endpoint to list all of the NFT filter objects a given webhook is subscribed to.
-      tags: ['Notify API Methods']
+      operationId: webhook-nft-filters
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
         - $ref: '#/components/schemas/webhook_id'
         - $ref: '#/components/schemas/limit'
         - $ref: '#/components/schemas/after'
+      responses:
+        '200':
+          description: Returns a list of nft filter objects.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/webhook_nft_filters_response'
       x-readme:
         samples-languages:
           - curl
@@ -610,25 +620,23 @@ paths:
               });
 
               const nftsByWebhook = await alchemy.notify.getNftFilters(hooks.webhooks[1]);
-      responses:
-        '200':
-          description: Returns a list of nft filter objects.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/webhook_nft_filters_response'
-      operationId: webhook-nft-filters
 
   /delete-webhook:
     delete:
+      tags: ['Notify API Methods']
       summary: Delete webhook
       description: 'Allows you to delete a webhook.'
-      tags: ['Notify API Methods']
+      operationId: delete-webhook
       parameters:
         - $ref: '#/components/schemas/X-Alchemy-Token'
         - $ref: '#/components/schemas/webhook_id'
+      responses:
+        '200':
+          description: 'Returns empty object.'
+          content:
+            application/json:
+              schema:
+                type: object
       x-readme:
         samples-languages:
           - curl
@@ -659,14 +667,6 @@ paths:
 
               await alchemy.notify.deleteWebhook("wh_qv16bt12wbj9ksss");
               await alchemy.notify.deleteWebhook(minedTxWebhook);
-      responses:
-        '200':
-          description: 'Returns empty object.'
-          content:
-            application/json:
-              schema:
-                type: object
-      operationId: delete-webhook
 
 components:
   schemas:

--- a/optimism/eth_feeHistory.yaml
+++ b/optimism/eth_feeHistory.yaml
@@ -7,7 +7,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_feeHistory - Optimism
       description: Returns a collection of historical gas information.
       operationId: eth-feeHistory

--- a/optimism/eth_feeHistory.yaml
+++ b/optimism/eth_feeHistory.yaml
@@ -6,55 +6,51 @@ servers:
   - url: 'https://opt-mainnet.g.alchemy.com/v2 '
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_feeHistory - Optimism
-        description: Returns a collection of historical gas information.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_feeHistory - Optimism
+      description: Returns a collection of historical gas information.
+      operationId: eth-feeHistory
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_feeHistory
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_feeHistory
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_feeHistory
-        operationId: eth-feeHistory
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                import { Network, Alchemy } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/eth_feeHistory
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ETH_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                // Using send method from alchemy-sdk with specific transaction details
-                const res = await alchemy.core.send('eth_feeHistory', [
-                  '0x5',
-                  'latest',
-                  []
-                ]);
+              // Using send method from alchemy-sdk with specific transaction details
+              const res = await alchemy.core.send('eth_feeHistory', [
+                '0x5',
+                'latest',
+                []
+              ]);
 
-                console.log(res);
+              console.log(res);

--- a/optimism/eth_feeHistory.yaml
+++ b/optimism/eth_feeHistory.yaml
@@ -15,19 +15,7 @@ components:
         description: Returns a collection of historical gas information.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/optimism/eth_getProof.yaml
+++ b/optimism/eth_getProof.yaml
@@ -12,54 +12,50 @@ servers:
         default: opt-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getProof - Optimism
-        description: Returns the account and storage values of the specified account including the Merkle-proof on Optimism. This call can be used to verify that the data you are pulling from is not tampered with.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: eth_getProof - Optimism
+      description: Returns the account and storage values of the specified account including the Merkle-proof on Optimism. This call can be used to verify that the data you are pulling from is not tampered with.
+      operationId: eth-getProof-optimism
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getProof
+      responses:
+        '200':
+          description: 'Returns the account and storage values of the specified account.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getProof
-        responses:
-          '200':
-            description: 'Returns the account and storage values of the specified account.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getProof
-        operationId: eth-getProof-optimism
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                import { Network, Alchemy } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/eth_getProof
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ETH_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                // Using send method from alchemy-sdk with specific transaction details
-                const res = await alchemy.core.send('eth_getProof', [
-                  '0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842',
-                  ["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],
-                  "latest",
-                ]);
+              // Using send method from alchemy-sdk with specific transaction details
+              const res = await alchemy.core.send('eth_getProof', [
+                '0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842',
+                ["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],
+                "latest",
+              ]);
 
-                console.log(res);
+              console.log(res);

--- a/optimism/eth_getProof.yaml
+++ b/optimism/eth_getProof.yaml
@@ -20,19 +20,7 @@ components:
         summary: eth_getProof - Optimism
         description: Returns the account and storage values of the specified account including the Merkle-proof on Optimism. This call can be used to verify that the data you are pulling from is not tampered with.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/optimism/eth_maxPriorityFeePerGas.yaml
+++ b/optimism/eth_maxPriorityFeePerGas.yaml
@@ -13,9 +13,9 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_maxPriorityFeePerGas - Optimism
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
-      tags: []
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:

--- a/optimism/eth_maxPriorityFeePerGas.yaml
+++ b/optimism/eth_maxPriorityFeePerGas.yaml
@@ -17,19 +17,7 @@ paths:
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/optimism/eth_maxPriorityFeePerGas.yaml
+++ b/optimism/eth_maxPriorityFeePerGas.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_maxPriorityFeePerGas - Optimism
       description: "Returns a fee per gas that is an estimate of how much you can pay as a priority fee, or 'tip', to get a transaction included in the current block."
       parameters:

--- a/optimism/eth_syncing.yaml
+++ b/optimism/eth_syncing.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_syncing - Optimism
       description: Returns a list of addresses owned by client.
       operationId: eth-syncing-optimism

--- a/optimism/eth_syncing.yaml
+++ b/optimism/eth_syncing.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns a list of addresses owned by client.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         description: Accepts nothing.
         content:

--- a/optimism/eth_syncing.yaml
+++ b/optimism/eth_syncing.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_syncing - Optimism
       description: Returns a list of addresses owned by client.
-      tags: []
+      operationId: eth-syncing-optimism
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -31,4 +32,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/eth_syncing
-      operationId: eth-syncing-optimism

--- a/polygon-pos/bor_getAuthor.yaml
+++ b/polygon-pos/bor_getAuthor.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: bor_getAuthor - Polygon PoS
       description: 'Returns address of Author on Polygon.'
-      tags: []
+      operationId: bor-getauthor-polygon
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -31,4 +32,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/bor_getAuthor
-      operationId: bor-getauthor-polygon

--- a/polygon-pos/bor_getAuthor.yaml
+++ b/polygon-pos/bor_getAuthor.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: bor_getAuthor - Polygon PoS
       description: 'Returns address of Author on Polygon.'
       operationId: bor-getauthor-polygon

--- a/polygon-pos/bor_getAuthor.yaml
+++ b/polygon-pos/bor_getAuthor.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Returns address of Author on Polygon.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         description: 'Block number (in hexadecimal format).'
         content:

--- a/polygon-pos/bor_getCurrentProposer.yaml
+++ b/polygon-pos/bor_getCurrentProposer.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: bor_getCurrentProposer - Polygon PoS
       description: "Returns current proposer's address on Polygon."
-      tags: []
+      operationId: bor-getcurrentproposer-polygon
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/bor_getCurrentProposer
-      operationId: bor-getcurrentproposer-polygon

--- a/polygon-pos/bor_getCurrentProposer.yaml
+++ b/polygon-pos/bor_getCurrentProposer.yaml
@@ -17,19 +17,7 @@ paths:
       description: "Returns current proposer's address on Polygon."
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/bor_getCurrentProposer.yaml
+++ b/polygon-pos/bor_getCurrentProposer.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: bor_getCurrentProposer - Polygon PoS
       description: "Returns current proposer's address on Polygon."
       operationId: bor-getcurrentproposer-polygon

--- a/polygon-pos/bor_getCurrentValidators.yaml
+++ b/polygon-pos/bor_getCurrentValidators.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: bor_getCurrentValidators - Polygon PoS
       description: 'Returns current validators for Polygon.'
       operationId: bor-getCurrentValidators-polygon

--- a/polygon-pos/bor_getCurrentValidators.yaml
+++ b/polygon-pos/bor_getCurrentValidators.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: bor_getCurrentValidators - Polygon PoS
       description: 'Returns current validators for Polygon.'
-      tags: []
+      operationId: bor-getCurrentValidators-polygon
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/bor_getCurrentValidators
-      operationId: bor-getCurrentValidators-polygon

--- a/polygon-pos/bor_getCurrentValidators.yaml
+++ b/polygon-pos/bor_getCurrentValidators.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Returns current validators for Polygon.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/bor_getRootHash.yaml
+++ b/polygon-pos/bor_getRootHash.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: bor_getRootHash - Polygon PoS
       description: 'Polygon API - Returns the root hash given a block range.'
-      tags: []
+      operationId: bor-getRootHash-polygon
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/bor_getRootHash
-      operationId: bor-getRootHash-polygon

--- a/polygon-pos/bor_getRootHash.yaml
+++ b/polygon-pos/bor_getRootHash.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Polygon API - Returns the root hash given a block range.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/bor_getRootHash.yaml
+++ b/polygon-pos/bor_getRootHash.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: bor_getRootHash - Polygon PoS
       description: 'Polygon API - Returns the root hash given a block range.'
       operationId: bor-getRootHash-polygon

--- a/polygon-pos/bor_getSignersAtHash.yaml
+++ b/polygon-pos/bor_getSignersAtHash.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Polygon API - Returns all the signers of the block matching the specified block hash.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/bor_getSignersAtHash.yaml
+++ b/polygon-pos/bor_getSignersAtHash.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: bor_getSignersAtHash - Polygon PoS
       description: 'Polygon API - Returns all the signers of the block matching the specified block hash.'
       operationId: bor-getSignersAtHash-polygon

--- a/polygon-pos/bor_getSignersAtHash.yaml
+++ b/polygon-pos/bor_getSignersAtHash.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: bor_getSignersAtHash - Polygon PoS
       description: 'Polygon API - Returns all the signers of the block matching the specified block hash.'
-      tags: []
+      operationId: bor-getSignersAtHash-polygon
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/bor_getSignersAtHash
-      operationId: bor-getSignersAtHash-polygon

--- a/polygon-pos/eth_blockNumber.yaml
+++ b/polygon-pos/eth_blockNumber.yaml
@@ -15,6 +15,7 @@ paths:
     post:
       summary: eth_blockNumber - Polygon PoS
       description: Returns the number of the most recent block on Polygon.
+      operationId: eth-blocknumber-polygon
       $ref: ../ethereum/eth_blockNumber.yaml#/components/pathItems/path/post
       x-readme:
         samples-languages:
@@ -38,4 +39,3 @@ paths:
 
               // Get the latest block number
               alchemy.core.getBlockNumber().then(console.log);
-      operationId: eth-blocknumber-polygon

--- a/polygon-pos/eth_feeHistory.yaml
+++ b/polygon-pos/eth_feeHistory.yaml
@@ -7,7 +7,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_feeHistory - Polygon PoS
       description: Returns a collection of historical gas information.
       operationId: eth-feeHistory

--- a/polygon-pos/eth_feeHistory.yaml
+++ b/polygon-pos/eth_feeHistory.yaml
@@ -6,55 +6,51 @@ servers:
   - url: 'https://polygon-mainnet.g.alchemy.com/v2 '
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_feeHistory - Polygon PoS
-        description: Returns a collection of historical gas information.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_feeHistory - Polygon PoS
+      description: Returns a collection of historical gas information.
+      operationId: eth-feeHistory
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_feeHistory
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_feeHistory
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_feeHistory
-        operationId: eth-feeHistory
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                import { Network, Alchemy } from "alchemy-sdk";
+                $ref: ../evm_responses.yaml#/eth_feeHistory
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              import { Network, Alchemy } from "alchemy-sdk";
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.ETH_MAINNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.ETH_MAINNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                // Using send method from alchemy-sdk with specific transaction details
-                const res = await alchemy.core.send('eth_feeHistory', [
-                  '0x5',
-                  'latest',
-                  []
-                ]);
+              // Using send method from alchemy-sdk with specific transaction details
+              const res = await alchemy.core.send('eth_feeHistory', [
+                '0x5',
+                'latest',
+                []
+              ]);
 
-                console.log(res);
+              console.log(res);

--- a/polygon-pos/eth_feeHistory.yaml
+++ b/polygon-pos/eth_feeHistory.yaml
@@ -15,19 +15,7 @@ components:
         description: Returns a collection of historical gas information.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-pos/eth_getProof.yaml
+++ b/polygon-pos/eth_getProof.yaml
@@ -20,19 +20,7 @@ components:
         summary: eth_getProof - Polygon PoS
         description: Returns the account and storage values of the specified account including the Merkle-proof on Polygon. This call can be used to verify that the data you are pulling from is not tampered with.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-pos/eth_getRootHash.yaml
+++ b/polygon-pos/eth_getRootHash.yaml
@@ -13,9 +13,9 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_getRootHash - Polygon PoS
       description: 'Returns the root hash given a block range on Polygon.'
-      tags: []
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:

--- a/polygon-pos/eth_getRootHash.yaml
+++ b/polygon-pos/eth_getRootHash.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Returns the root hash given a block range on Polygon.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/eth_getRootHash.yaml
+++ b/polygon-pos/eth_getRootHash.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getRootHash - Polygon PoS
       description: 'Returns the root hash given a block range on Polygon.'
       parameters:

--- a/polygon-pos/eth_getSignersAtHash.yaml
+++ b/polygon-pos/eth_getSignersAtHash.yaml
@@ -13,9 +13,9 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_getSignersAtHash - Polygon PoS
       description: 'Polygon API - Returns all signs given a blockhash.'
-      tags: []
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:

--- a/polygon-pos/eth_getSignersAtHash.yaml
+++ b/polygon-pos/eth_getSignersAtHash.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getSignersAtHash - Polygon PoS
       description: 'Polygon API - Returns all signs given a blockhash.'
       parameters:

--- a/polygon-pos/eth_getSignersAtHash.yaml
+++ b/polygon-pos/eth_getSignersAtHash.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Polygon API - Returns all signs given a blockhash.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/eth_getTransactionReceiptsByBlock.yaml
+++ b/polygon-pos/eth_getTransactionReceiptsByBlock.yaml
@@ -13,9 +13,9 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_getTransactionReceiptsByBlock - Polygon PoS
       description: 'Polygon API - Returns all transaction receipts for the given block number or hash.'
-      tags: []
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:

--- a/polygon-pos/eth_getTransactionReceiptsByBlock.yaml
+++ b/polygon-pos/eth_getTransactionReceiptsByBlock.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getTransactionReceiptsByBlock - Polygon PoS
       description: 'Polygon API - Returns all transaction receipts for the given block number or hash.'
       parameters:

--- a/polygon-pos/eth_getTransactionReceiptsByBlock.yaml
+++ b/polygon-pos/eth_getTransactionReceiptsByBlock.yaml
@@ -17,19 +17,7 @@ paths:
       description: 'Polygon API - Returns all transaction receipts for the given block number or hash.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/eth_sendRawTransaction.yaml
+++ b/polygon-pos/eth_sendRawTransaction.yaml
@@ -19,19 +19,7 @@ paths:
         </br><strong> Note: </strong> Due to network constraints, transactions on Polygon Mainnet must be submitted with a minimum gasPrice of 30 gwei.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/polygon-pos/eth_sendRawTransaction.yaml
+++ b/polygon-pos/eth_sendRawTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_sendRawTransaction - Polygon PoS
       description: |
         Creates a new message call transaction or a contract creation for signed transactions.

--- a/polygon-pos/eth_sendRawTransaction.yaml
+++ b/polygon-pos/eth_sendRawTransaction.yaml
@@ -13,11 +13,12 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: eth_sendRawTransaction - Polygon PoS
       description: |
         Creates a new message call transaction or a contract creation for signed transactions.
         </br><strong> Note: </strong> Due to network constraints, transactions on Polygon Mainnet must be submitted with a minimum gasPrice of 30 gwei.
-      tags: []
+      operationId: eth-sendRawTransaction-polygon
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -25,6 +26,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/eth_sendRawTransaction
+      responses:
+        '200':
+          description: 'Returns 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/string_result_response
       x-readme:
         samples-languages:
           - curl
@@ -61,11 +69,3 @@ paths:
 
               const rawTransaction = await wallet.signTransaction(transaction);
               await alchemy.transact.sendTransaction(rawTransaction);
-      responses:
-        '200':
-          description: 'Returns 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/string_result_response
-      operationId: eth-sendRawTransaction-polygon

--- a/polygon-zkevm/eth_call.yaml
+++ b/polygon-zkevm/eth_call.yaml
@@ -13,53 +13,49 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: eth-call-polygon-zkevm
-        summary: eth_call - Polygon zkEVM
-        description: Executes a new message call immediately without creating a transaction on the blockchain.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Accepts the transaction call object and the block number / block hash / block tag to execute the call on.
+    post:
+      operationId: eth-call-polygon-zkevm
+      summary: eth_call - Polygon zkEVM
+      description: Executes a new message call immediately without creating a transaction on the blockchain.
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Accepts the transaction call object and the block number / block hash / block tag to execute the call on.
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_call_polygon_zkevm
+      responses:
+        '200':
+          description: The result of the call.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_call_polygon_zkevm
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                const { Network, Alchemy } = require ("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/eth_call
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              const { Network, Alchemy } = require ("alchemy-sdk");
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                // Make a sample eth_call
-                alchemy.core
-                  .call({
-                    to: "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
-                    data: "0x3b3b57debf074faa138b72c65adbdcfb329847e4f2c04bde7f7dd7fcad5a52d2f395a558",
-                  })
-                  .then(console.log);
-        responses:
-          '200':
-            description: The result of the call.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_call
+              // Make a sample eth_call
+              alchemy.core
+                .call({
+                  to: "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
+                  data: "0x3b3b57debf074faa138b72c65adbdcfb329847e4f2c04bde7f7dd7fcad5a52d2f395a558",
+                })
+                .then(console.log);

--- a/polygon-zkevm/eth_call.yaml
+++ b/polygon-zkevm/eth_call.yaml
@@ -22,19 +22,7 @@ components:
         summary: eth_call - Polygon zkEVM
         description: Executes a new message call immediately without creating a transaction on the blockchain.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts the transaction call object and the block number / block hash / block tag to execute the call on.
           content:

--- a/polygon-zkevm/eth_estimateGas.yaml
+++ b/polygon-zkevm/eth_estimateGas.yaml
@@ -21,19 +21,7 @@ components:
         description: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_estimateGas.yaml
+++ b/polygon-zkevm/eth_estimateGas.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_estimateGas - Polygon zkEVM
       description: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain.
       operationId: eth-estimateGas-polygon-zkevm

--- a/polygon-zkevm/eth_estimateGas.yaml
+++ b/polygon-zkevm/eth_estimateGas.yaml
@@ -12,52 +12,48 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_estimateGas - Polygon zkEVM
-        description: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_estimateGas - Polygon zkEVM
+      description: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete. The transaction will not be added to the blockchain.
+      operationId: eth-estimateGas-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_estimateGas_polygon_zkEVM
+      responses:
+        '200':
+          description: Returns the amount of gas used.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_estimateGas_polygon_zkEVM
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                const { Network, Alchemy } = require("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/string_result_response
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              const { Network, Alchemy } = require("alchemy-sdk");
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core
-                  .estimateGas({
-                    to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-                    data: "0xd0e30db0",
-                  })
-                  .then(console.log);
-        responses:
-          '200':
-            description: Returns the amount of gas used.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/string_result_response
-        operationId: eth-estimateGas-polygon-zkevm
+              alchemy.core
+                .estimateGas({
+                  to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                  data: "0xd0e30db0",
+                })
+                .then(console.log);

--- a/polygon-zkevm/eth_getBalance.yaml
+++ b/polygon-zkevm/eth_getBalance.yaml
@@ -12,47 +12,42 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        tags: []
-        summary: eth_getBalance - Polygon zkEVM
-        description: Returns the balance of the account of a given address on Polygon zkEVM.
-        operationId: eth-getBalance-polygon-zkevm
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: eth_getBalance - Polygon zkEVM
+      description: Returns the balance of the account of a given address on Polygon zkEVM.
+      operationId: eth-getBalance-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getBalance_polygon_zkevm
+      responses:
+        '200':
+          description: 'Returns hex value of the current ETH balance for the given address, measured in wei.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getBalance_polygon_zkevm
-        responses:
-          '200':
-            description: 'Returns hex value of the current ETH balance for the given address, measured in wei.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/string_result_response
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                const { Network, Alchemy } = require("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/string_result_response
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              const { Network, Alchemy } = require("alchemy-sdk");
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core.getBalance("0xbed9dA8f130aCC29F2580df183F3995eff78fb4D", "latest").then(console.log);
+              alchemy.core.getBalance("0xbed9dA8f130aCC29F2580df183F3995eff78fb4D", "latest").then(console.log);

--- a/polygon-zkevm/eth_getBalance.yaml
+++ b/polygon-zkevm/eth_getBalance.yaml
@@ -17,9 +17,10 @@ components:
   pathItems:
     path:
       post:
+        tags: []
         summary: eth_getBalance - Polygon zkEVM
         description: Returns the balance of the account of a given address on Polygon zkEVM.
-        tags: []
+        operationId: eth-getBalance-polygon-zkevm
         parameters:
           - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
@@ -27,6 +28,13 @@ components:
             application/json:
               schema:
                 $ref: ../evm_body.yaml#/eth_getBalance_polygon_zkevm
+        responses:
+          '200':
+            description: 'Returns hex value of the current ETH balance for the given address, measured in wei.'
+            content:
+              application/json:
+                schema:
+                  $ref: ../evm_responses.yaml#/string_result_response
         x-readme:
           samples-languages:
             - curl
@@ -48,11 +56,3 @@ components:
                 const alchemy = new Alchemy(settings);
 
                 alchemy.core.getBalance("0xbed9dA8f130aCC29F2580df183F3995eff78fb4D", "latest").then(console.log);
-        responses:
-          '200':
-            description: 'Returns hex value of the current ETH balance for the given address, measured in wei.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/string_result_response
-        operationId: eth-getBalance-polygon-zkevm

--- a/polygon-zkevm/eth_getBalance.yaml
+++ b/polygon-zkevm/eth_getBalance.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns the balance of the account of a given address on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getCode.yaml
+++ b/polygon-zkevm/eth_getCode.yaml
@@ -12,47 +12,43 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getCode - Polygon zkEVM
-        description: Returns code at a given address on the Polygon zkEVM network.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getCode - Polygon zkEVM
+      description: Returns code at a given address on the Polygon zkEVM network.
+      operationId: eth-getCode-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getCode_polygon_zkevm
+      responses:
+        '200':
+          description: Returns the code from the given address.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getCode_polygon_zkevm
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                const { Alchemy, Network } = require("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/string_result_response
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              const { Alchemy, Network } = require("alchemy-sdk");
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core.getCode("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").then(console.log);
-        responses:
-          '200':
-            description: Returns the code from the given address.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/string_result_response
-        operationId: eth-getCode-polygon-zkevm
+              alchemy.core.getCode("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").then(console.log);

--- a/polygon-zkevm/eth_getCode.yaml
+++ b/polygon-zkevm/eth_getCode.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns code at a given address on the Polygon zkEVM network.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getCode.yaml
+++ b/polygon-zkevm/eth_getCode.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getCode - Polygon zkEVM
       description: Returns code at a given address on the Polygon zkEVM network.
       operationId: eth-getCode-polygon-zkevm

--- a/polygon-zkevm/eth_getCompilers.yaml
+++ b/polygon-zkevm/eth_getCompilers.yaml
@@ -12,54 +12,49 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        tags: []
-        summary: eth_getCompilers - Polygon zkEVM
-        description: Returns a list of installed compilers (Deprecated). Response is always empty in Polygon zkEVM.
-        operationId: eth-getCompilers-polygon-zkevm
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Accepts nothing.
+    post:
+      summary: eth_getCompilers - Polygon zkEVM
+      description: Returns a list of installed compilers (Deprecated). Response is always empty in Polygon zkEVM.
+      operationId: eth-getCompilers-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Accepts nothing.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  $ref: ../components/schemas.yaml#/Id
+                jsonrpc:
+                  $ref: ../components/schemas.yaml#/JsonRpc
+                method:
+                  $ref: ../components/schemas.yaml#/Method
+                  default: eth_getCompilers
+      responses:
+        '200':
+          description: Response is always empty.
           content:
             application/json:
               schema:
                 type: object
+                required:
+                  - id
+                  - jsonrpc
+                  - result
                 properties:
                   id:
                     $ref: ../components/schemas.yaml#/Id
                   jsonrpc:
                     $ref: ../components/schemas.yaml#/JsonRpc
-                  method:
-                    $ref: ../components/schemas.yaml#/Method
-                    default: eth_getCompilers
-        responses:
-          '200':
-            description: Response is always empty.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  required:
-                    - id
-                    - jsonrpc
-                    - result
-                  properties:
-                    id:
-                      $ref: ../components/schemas.yaml#/Id
-                    jsonrpc:
-                      $ref: ../components/schemas.yaml#/JsonRpc
-                    result:
-                      type: array
-                      items:
-                        type: string
-                      example: []
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
+                  result:
+                    type: array
+                    items:
+                      type: string
+                    example: []
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/eth_getCompilers.yaml
+++ b/polygon-zkevm/eth_getCompilers.yaml
@@ -17,9 +17,10 @@ components:
   pathItems:
     path:
       post:
+        tags: []
         summary: eth_getCompilers - Polygon zkEVM
         description: Returns a list of installed compilers (Deprecated). Response is always empty in Polygon zkEVM.
-        tags: []
+        operationId: eth-getCompilers-polygon-zkevm
         parameters:
           - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
@@ -36,11 +37,6 @@ components:
                   method:
                     $ref: ../components/schemas.yaml#/Method
                     default: eth_getCompilers
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
         responses:
           '200':
             description: Response is always empty.
@@ -62,4 +58,8 @@ components:
                       items:
                         type: string
                       example: []
-        operationId: eth-getCompilers-polygon-zkevm
+        x-readme:
+          samples-languages:
+            - curl
+            - javascript
+            - python

--- a/polygon-zkevm/eth_getCompilers.yaml
+++ b/polygon-zkevm/eth_getCompilers.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns a list of installed compilers (Deprecated). Response is always empty in Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts nothing.
           content:

--- a/polygon-zkevm/eth_getStorageAt.yaml
+++ b/polygon-zkevm/eth_getStorageAt.yaml
@@ -12,47 +12,43 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getStorageAt - Polygon zkEVM
-        description: "Returns the value from a storage position at a given address on the Polygon zkEVM network, or in other words, returns the state of the contract's storage, which may not be exposed via the contract's methods."
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getStorageAt - Polygon zkEVM
+      description: "Returns the value from a storage position at a given address on the Polygon zkEVM network, or in other words, returns the state of the contract's storage, which may not be exposed via the contract's methods."
+      operationId: eth-getStorageAt-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getStorageAt_polygon_zkevm
+      responses:
+        '200':
+          description: Returns the value at this storage position.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getStorageAt_polygon_zkevm
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                const { Alchemy, Network } = require("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/string_result_response
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              const { Alchemy, Network } = require("alchemy-sdk");
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core.getStorageAt("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 0).then(console.log);
-        responses:
-          '200':
-            description: Returns the value at this storage position.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/string_result_response
-        operationId: eth-getStorageAt-polygon-zkevm
+              alchemy.core.getStorageAt("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 0).then(console.log);

--- a/polygon-zkevm/eth_getStorageAt.yaml
+++ b/polygon-zkevm/eth_getStorageAt.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getStorageAt - Polygon zkEVM
       description: "Returns the value from a storage position at a given address on the Polygon zkEVM network, or in other words, returns the state of the contract's storage, which may not be exposed via the contract's methods."
       operationId: eth-getStorageAt-polygon-zkevm

--- a/polygon-zkevm/eth_getStorageAt.yaml
+++ b/polygon-zkevm/eth_getStorageAt.yaml
@@ -21,19 +21,7 @@ components:
         description: "Returns the value from a storage position at a given address on the Polygon zkEVM network, or in other words, returns the state of the contract's storage, which may not be exposed via the contract's methods."
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns information about a transaction by block number and transaction index position.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getTransactionByBlockNumberAndIndex - Polygon zkEVM
       description: Returns information about a transaction by block number and transaction index position.
       operationId: eth-getTransactionByBlockNumberAndIndex-polygon-zkevm

--- a/polygon-zkevm/eth_getTransactionByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getTransactionByBlockNumberAndIndex.yaml
@@ -12,31 +12,27 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getTransactionByBlockNumberAndIndex - Polygon zkEVM
-        description: Returns information about a transaction by block number and transaction index position.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getTransactionByBlockNumberAndIndex - Polygon zkEVM
+      description: Returns information about a transaction by block number and transaction index position.
+      operationId: eth-getTransactionByBlockNumberAndIndex-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getTransactionByBlockNumberAndIndex_polygon_zkevm
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getTransactionByBlockNumberAndIndex_polygon_zkevm
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_block
-        operationId: eth-getTransactionByBlockNumberAndIndex-polygon-zkevm
+                $ref: ../evm_responses.yaml#/eth_block
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/eth_getTransactionReceipt.yaml
+++ b/polygon-zkevm/eth_getTransactionReceipt.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns the receipt of a transaction by transaction hash on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getTransactionReceipt.yaml
+++ b/polygon-zkevm/eth_getTransactionReceipt.yaml
@@ -12,51 +12,47 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getTransactionReceipt - Polygon zkEVM
-        description: Returns the receipt of a transaction by transaction hash on Polygon zkEVM.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getTransactionReceipt - Polygon zkEVM
+      description: Returns the receipt of a transaction by transaction hash on Polygon zkEVM.
+      operationId: eth-getTransactionReceipt-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getTransactionReceipt
+      responses:
+        '200':
+          description: ''
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getTransactionReceipt
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Setup: npm install alchemy-sdk
-                // Github: https://github.com/alchemyplatform/alchemy-sdk-js
-                const { Alchemy, Network } = require("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/eth_getTransactionReceipt_zkevm
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Setup: npm install alchemy-sdk
+              // Github: https://github.com/alchemyplatform/alchemy-sdk-js
+              const { Alchemy, Network } = require("alchemy-sdk");
 
-                // Optional config object, but defaults to demo api-key and eth-mainnet.
-                const settings = {
-                  apiKey: "demo", // Replace with your Alchemy API Key.
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
-                };
-                const alchemy = new Alchemy(settings);
+              // Optional config object, but defaults to demo api-key and eth-mainnet.
+              const settings = {
+                apiKey: "demo", // Replace with your Alchemy API Key.
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+              const alchemy = new Alchemy(settings);
 
-                alchemy.core
-                  .getTransactionReceipt(
-                    "0x60b66de803f7bd34e40a122c30526b74914154ccba03f1f770958cccc9b59038"
-                  )
-                  .then(console.log);
-        responses:
-          '200':
-            description: ''
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/eth_getTransactionReceipt_zkevm
-        operationId: eth-getTransactionReceipt-zkevm
+              alchemy.core
+                .getTransactionReceipt(
+                  "0x60b66de803f7bd34e40a122c30526b74914154ccba03f1f770958cccc9b59038"
+                )
+                .then(console.log);

--- a/polygon-zkevm/eth_getTransactionReceipt.yaml
+++ b/polygon-zkevm/eth_getTransactionReceipt.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getTransactionReceipt - Polygon zkEVM
       description: Returns the receipt of a transaction by transaction hash on Polygon zkEVM.
       operationId: eth-getTransactionReceipt-zkevm

--- a/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
@@ -12,40 +12,36 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getUncleByBlockHashAndIndex - Polygon zkEVM
-        description: Returns information about an uncle block by block hash and uncle index position. Response for this method is always empty on Polygon zkEVM.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getUncleByBlockHashAndIndex - Polygon zkEVM
+      description: Returns information about an uncle block by block hash and uncle index position. Response for this method is always empty on Polygon zkEVM.
+      operationId: eth-getUncleByBlockHashAndIndex-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getUncleByBlockHashAndIndex
+      responses:
+        '200':
+          description: Response is always empty.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getUncleByBlockHashAndIndex
-        responses:
-          '200':
-            description: Response is always empty.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  required:
-                    - id
-                    - jsonrpc
-                    - result
-                  properties:
-                    id:
-                      $ref: ../components/schemas.yaml#/Id
-                    jsonrpc:
-                      $ref: ../components/schemas.yaml#/JsonRpc
-                    result:
-                      type: array
-                      items:
-                        type: string
-                      example: []
-        operationId: eth-getUncleByBlockHashAndIndex-polygon-zkevm
+                type: object
+                required:
+                  - id
+                  - jsonrpc
+                  - result
+                properties:
+                  id:
+                    $ref: ../components/schemas.yaml#/Id
+                  jsonrpc:
+                    $ref: ../components/schemas.yaml#/JsonRpc
+                  result:
+                    type: array
+                    items:
+                      type: string
+                    example: []

--- a/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns information about an uncle block by block hash and uncle index position. Response for this method is always empty on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockHashAndIndex.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getUncleByBlockHashAndIndex - Polygon zkEVM
       description: Returns information about an uncle block by block hash and uncle index position. Response for this method is always empty on Polygon zkEVM.
       operationId: eth-getUncleByBlockHashAndIndex-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns information about an uncle block by block number and uncle index position. Response for this method is always empty on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getUncleByBlockNumberAndIndex - Polygon zkEVM
       description: Returns information about an uncle block by block number and uncle index position. Response for this method is always empty on Polygon zkEVM.
       operationId: eth-getUncleByBlockNumberAndIndex-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
+++ b/polygon-zkevm/eth_getUncleByBlockNumberAndIndex.yaml
@@ -12,40 +12,36 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getUncleByBlockNumberAndIndex - Polygon zkEVM
-        description: Returns information about an uncle block by block number and uncle index position. Response for this method is always empty on Polygon zkEVM.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getUncleByBlockNumberAndIndex - Polygon zkEVM
+      description: Returns information about an uncle block by block number and uncle index position. Response for this method is always empty on Polygon zkEVM.
+      operationId: eth-getUncleByBlockNumberAndIndex-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getUncleByBlockNumberAndIndex
+      responses:
+        '200':
+          description: Response is always empty.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getUncleByBlockNumberAndIndex
-        responses:
-          '200':
-            description: Response is always empty.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  required:
-                    - id
-                    - jsonrpc
-                    - result
-                  properties:
-                    id:
-                      $ref: ../components/schemas.yaml#/Id
-                    jsonrpc:
-                      $ref: ../components/schemas.yaml#/JsonRpc
-                    result:
-                      type: array
-                      items:
-                        type: string
-                      example: []
-        operationId: eth-getUncleByBlockNumberAndIndex-polygon-zkevm
+                type: object
+                required:
+                  - id
+                  - jsonrpc
+                  - result
+                properties:
+                  id:
+                    $ref: ../components/schemas.yaml#/Id
+                  jsonrpc:
+                    $ref: ../components/schemas.yaml#/JsonRpc
+                  result:
+                    type: array
+                    items:
+                      type: string
+                    example: []

--- a/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
@@ -12,43 +12,39 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getUncleCountByBlockHash - Polygon zkEVM
-        description: Returns the number of uncles in a block specified by block hash. Response for this method is always 0 on Polygon zkEVM.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getUncleCountByBlockHash - Polygon zkEVM
+      description: Returns the number of uncles in a block specified by block hash. Response for this method is always 0 on Polygon zkEVM.
+      operationId: eth-getUncleCountByBlockHash-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getUncleCountByBlockHash
+      responses:
+        '200':
+          description: Response is always 0.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getUncleCountByBlockHash
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Response is always 0.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  required:
-                    - id
-                    - jsonrpc
-                    - result
-                  properties:
-                    id:
-                      $ref: ../components/schemas.yaml#/Id
-                    jsonrpc:
-                      $ref: ../components/schemas.yaml#/JsonRpc
-                    result:
-                      type: integer
-                      example: 0
-        operationId: eth-getUncleCountByBlockHash-polygon-zkevm
+                type: object
+                required:
+                  - id
+                  - jsonrpc
+                  - result
+                properties:
+                  id:
+                    $ref: ../components/schemas.yaml#/Id
+                  jsonrpc:
+                    $ref: ../components/schemas.yaml#/JsonRpc
+                  result:
+                    type: integer
+                    example: 0
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns the number of uncles in a block specified by block hash. Response for this method is always 0 on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockHash.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getUncleCountByBlockHash - Polygon zkEVM
       description: Returns the number of uncles in a block specified by block hash. Response for this method is always 0 on Polygon zkEVM.
       operationId: eth-getUncleCountByBlockHash-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
@@ -12,43 +12,39 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_getUncleCountByBlockNumber - Polygon zkEVM
-        description: Returns the number of uncles in a block specified by block number. Response for this method is always 0 on Polygon zkEVM.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_getUncleCountByBlockNumber - Polygon zkEVM
+      description: Returns the number of uncles in a block specified by block number. Response for this method is always 0 on Polygon zkEVM.
+      operationId: eth-getUncleCountByBlockNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_getUncleCountByBlockNumber
+      responses:
+        '200':
+          description: Response is always 0.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_getUncleCountByBlockNumber
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Response is always 0.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  required:
-                    - id
-                    - jsonrpc
-                    - result
-                  properties:
-                    id:
-                      $ref: ../components/schemas.yaml#/Id
-                    jsonrpc:
-                      $ref: ../components/schemas.yaml#/JsonRpc
-                    result:
-                      type: integer
-                      example: 0
-        operationId: eth-getUncleCountByBlockNumber-polygon-zkevm
+                type: object
+                required:
+                  - id
+                  - jsonrpc
+                  - result
+                properties:
+                  id:
+                    $ref: ../components/schemas.yaml#/Id
+                  jsonrpc:
+                    $ref: ../components/schemas.yaml#/JsonRpc
+                  result:
+                    type: integer
+                    example: 0
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_getUncleCountByBlockNumber - Polygon zkEVM
       description: Returns the number of uncles in a block specified by block number. Response for this method is always 0 on Polygon zkEVM.
       operationId: eth-getUncleCountByBlockNumber-polygon-zkevm

--- a/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
+++ b/polygon-zkevm/eth_getUncleCountByBlockNumber.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns the number of uncles in a block specified by block number. Response for this method is always 0 on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_protocolVersion.yaml
+++ b/polygon-zkevm/eth_protocolVersion.yaml
@@ -21,19 +21,7 @@ components:
         description: Returns the current network protocol version as a string. Response for this method is always 0 on Polygon zkEVM.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_protocolVersion.yaml
+++ b/polygon-zkevm/eth_protocolVersion.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_protocolVersion - Polygon zkEVM
       description: Returns the current network protocol version as a string. Response for this method is always 0 on Polygon zkEVM.
       operationId: eth-protocolVersion-polygon-zkevm

--- a/polygon-zkevm/eth_protocolVersion.yaml
+++ b/polygon-zkevm/eth_protocolVersion.yaml
@@ -12,43 +12,39 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_protocolVersion - Polygon zkEVM
-        description: Returns the current network protocol version as a string. Response for this method is always 0 on Polygon zkEVM.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_protocolVersion - Polygon zkEVM
+      description: Returns the current network protocol version as a string. Response for this method is always 0 on Polygon zkEVM.
+      operationId: eth-protocolVersion-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_protocolVersion
+      responses:
+        '200':
+          description: Response is always 0.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_protocolVersion
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Response is always 0.
-            content:
-              application/json:
-                schema:
-                  type: object
-                  required:
-                    - id
-                    - jsonrpc
-                    - result
-                  properties:
-                    id:
-                      $ref: ../components/schemas.yaml#/Id
-                    jsonrpc:
-                      $ref: ../components/schemas.yaml#/JsonRpc
-                    result:
-                      type: integer
-                      example: 0
-        operationId: eth-protocolVersion-polygon-zkevm
+                type: object
+                required:
+                  - id
+                  - jsonrpc
+                  - result
+                properties:
+                  id:
+                    $ref: ../components/schemas.yaml#/Id
+                  jsonrpc:
+                    $ref: ../components/schemas.yaml#/JsonRpc
+                  result:
+                    type: integer
+                    example: 0
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/eth_sendRawTransaction.yaml
+++ b/polygon-zkevm/eth_sendRawTransaction.yaml
@@ -21,19 +21,7 @@ components:
         description: Creates a new message call transaction or a contract creation for signed transactions on the Polygon zkEVM network.
         tags: []
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/eth_sendRawTransaction.yaml
+++ b/polygon-zkevm/eth_sendRawTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: eth_sendRawTransaction - Polygon zkEVM
       description: Creates a new message call transaction or a contract creation for signed transactions on the Polygon zkEVM network.
       operationId: eth-sendRawTransaction-polygon-zkevm

--- a/polygon-zkevm/eth_sendRawTransaction.yaml
+++ b/polygon-zkevm/eth_sendRawTransaction.yaml
@@ -12,81 +12,77 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        summary: eth_sendRawTransaction - Polygon zkEVM
-        description: Creates a new message call transaction or a contract creation for signed transactions on the Polygon zkEVM network.
-        tags: []
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      tags: []
+      summary: eth_sendRawTransaction - Polygon zkEVM
+      description: Creates a new message call transaction or a contract creation for signed transactions on the Polygon zkEVM network.
+      operationId: eth-sendRawTransaction-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/eth_sendRawTransaction
+      responses:
+        '200':
+          description: 'Returns 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.'
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/eth_sendRawTransaction
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-          code-samples:
-            - language: javascript
-              name: Alchemy SDK
-              code: |
-                // Import the Alchemy SDK
-                const { Network, Alchemy, Wallet, Utils } = require("alchemy-sdk");
+                $ref: ../evm_responses.yaml#/string_result_response
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python
+        code-samples:
+          - language: javascript
+            name: Alchemy SDK
+            code: |
+              // Import the Alchemy SDK
+              const { Network, Alchemy, Wallet, Utils } = require("alchemy-sdk");
 
-                const API_KEY = "demo" // Replace with your Alchemy API key
+              const API_KEY = "demo" // Replace with your Alchemy API key
 
-                // Replace with your Private Key
-                const PRIVATE_KEY = "ae43266e69d4bcc923fe66083fe8f027be148af839a70b2f11cad554a6f0798b"
+              // Replace with your Private Key
+              const PRIVATE_KEY = "ae43266e69d4bcc923fe66083fe8f027be148af839a70b2f11cad554a6f0798b"
 
-                // NOTE: A demo private key is given in this case but never use it for real transactions as it's now public.
+              // NOTE: A demo private key is given in this case but never use it for real transactions as it's now public.
 
-                // Configuring the Alchemy SDK
-                const settings = {
-                  apiKey: API_KEY,
-                  network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              // Configuring the Alchemy SDK
+              const settings = {
+                apiKey: API_KEY,
+                network: Network.POLYGONZKEVM_TESTNET, // Replace with your network.
+              };
+
+              // Creating a new alchemy instance
+              const alchemy = new Alchemy(settings);
+
+              async function main() {
+                // Creating a new wallet instance
+                const wallet = new Wallet(PRIVATE_KEY);
+
+                // creating the transaction object
+                const transaction = {
+                  to: "0xbed9dA8f130aCC29F2580df183F3995eff78fb4D",
+                  value: Utils.parseEther("0.001"),
+                  gasLimit: "21000",
+                  maxPriorityFeePerGas: Utils.parseUnits("5", "gwei"),
+                  maxFeePerGas: Utils.parseUnits("20", "gwei"),
+                  nonce: await alchemy.core.getTransactionCount(wallet.getAddress()),
+                  type: 2,
+                  chainId: 1442, 
                 };
 
-                // Creating a new alchemy instance
-                const alchemy = new Alchemy(settings);
+                // signing the transaction
+                const rawTransaction = await wallet.signTransaction(transaction);
 
-                async function main() {
-                  // Creating a new wallet instance
-                  const wallet = new Wallet(PRIVATE_KEY);
+                // sending the transaction
+                let sentTx = await alchemy.transact.sendTransaction(rawTransaction);
 
-                  // creating the transaction object
-                  const transaction = {
-                    to: "0xbed9dA8f130aCC29F2580df183F3995eff78fb4D",
-                    value: Utils.parseEther("0.001"),
-                    gasLimit: "21000",
-                    maxPriorityFeePerGas: Utils.parseUnits("5", "gwei"),
-                    maxFeePerGas: Utils.parseUnits("20", "gwei"),
-                    nonce: await alchemy.core.getTransactionCount(wallet.getAddress()),
-                    type: 2,
-                    chainId: 1442, 
-                  };
+                // Logging the sent tx object
+                console.log(sentTx);
+              }
 
-                  // signing the transaction
-                  const rawTransaction = await wallet.signTransaction(transaction);
-
-                  // sending the transaction
-                  let sentTx = await alchemy.transact.sendTransaction(rawTransaction);
-
-                  // Logging the sent tx object
-                  console.log(sentTx);
-                }
-
-                main();
-        responses:
-          '200':
-            description: 'Returns 32 Bytes - the transaction hash, or the zero hash if the transaction is not yet available.'
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/string_result_response
-        operationId: eth-sendRawTransaction-polygon-zkevm
+              main();

--- a/polygon-zkevm/zkevm_batchNumber.yaml
+++ b/polygon-zkevm/zkevm_batchNumber.yaml
@@ -13,30 +13,26 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-batchNumber-polygon-zkevm
-        summary: zkevm_batchNumber - Polygon zkEVM
-        description: Returns the latest batch number.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: zkevm_batchNumber - Polygon zkEVM
+      description: Returns the latest batch number.
+      operationId: zkevm-batchNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/zkevm_batchNumber'
+      responses:
+        '200':
+          description: Returns the latest batch number.
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/zkevm_batchNumber'
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns the latest batch number.
-            content:
-              application/json:
-                schema:
-                  $ref: '../evm_responses.yaml#/zkevm_batchNumber'
+                $ref: '../evm_responses.yaml#/zkevm_batchNumber'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_batchNumber.yaml
+++ b/polygon-zkevm/zkevm_batchNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_batchNumber - Polygon zkEVM
         description: Returns the latest batch number.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/zkevm_batchNumberByBlockNumber.yaml
+++ b/polygon-zkevm/zkevm_batchNumberByBlockNumber.yaml
@@ -13,30 +13,26 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-batchNumberByBlockNumber-polygon-zkevm
-        summary: zkevm_batchNumberByBlockNumber - Polygon zkEVM
-        description: Returns the batch number of the batch connected to the block.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: zkevm_batchNumberByBlockNumber - Polygon zkEVM
+      description: Returns the batch number of the batch connected to the block.
+      operationId: zkevm-batchNumberByBlockNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/zkevm_batchNumberByBlockNumber'
+      responses:
+        '200':
+          description: Returns the batch number of the batch connected to the block.
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/zkevm_batchNumberByBlockNumber'
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns the batch number of the batch connected to the block.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/zkevm_batchNumberByBlockNumber
+                $ref: ../evm_responses.yaml#/zkevm_batchNumberByBlockNumber
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_batchNumberByBlockNumber.yaml
+++ b/polygon-zkevm/zkevm_batchNumberByBlockNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_batchNumberByBlockNumber - Polygon zkEVM
         description: Returns the batch number of the batch connected to the block.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/zkevm_consolidatedBlockNumber.yaml
+++ b/polygon-zkevm/zkevm_consolidatedBlockNumber.yaml
@@ -13,31 +13,27 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-consolidatedBlockNumber-polygon-zkevm
-        summary: zkevm_consolidatedBlockNumber - Polygon zkEVM
-        description: Returns the latest block number that is connected to the latest batch verified.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Accepts no parameters.
+    post:
+      summary: zkevm_consolidatedBlockNumber - Polygon zkEVM
+      description: Returns the latest block number that is connected to the latest batch verified.
+      operationId: zkevm-consolidatedBlockNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Accepts no parameters.
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/zkevm_consolidatedBlockNumber
+      responses:
+        '200':
+          description: The latest block number that is connected to the latest batch verified.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/zkevm_consolidatedBlockNumber
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The latest block number that is connected to the latest batch verified.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/zkevm_consolidatedBlockNumber
+                $ref: ../evm_responses.yaml#/zkevm_consolidatedBlockNumber
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_consolidatedBlockNumber.yaml
+++ b/polygon-zkevm/zkevm_consolidatedBlockNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_consolidatedBlockNumber - Polygon zkEVM
         description: Returns the latest block number that is connected to the latest batch verified.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Accepts no parameters.
           content:

--- a/polygon-zkevm/zkevm_getBatchByNumber.yaml
+++ b/polygon-zkevm/zkevm_getBatchByNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_getBatchByNumber - Polygon zkEVM
         description: Returns information about the batch identified by the provided batch number or tag.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/zkevm_getBatchByNumber.yaml
+++ b/polygon-zkevm/zkevm_getBatchByNumber.yaml
@@ -13,30 +13,26 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-getBatchByNumber-polygon-zkevm
-        summary: zkevm_getBatchByNumber - Polygon zkEVM
-        description: Returns information about the batch identified by the provided batch number or tag.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: zkevm_getBatchByNumber - Polygon zkEVM
+      description: Returns information about the batch identified by the provided batch number or tag.
+      operationId: zkevm-getBatchByNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/zkevm_getBatchByNumber'
+      responses:
+        '200':
+          description: Returns information about the batch identified by the provided batch number or tag.
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/zkevm_getBatchByNumber'
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns information about the batch identified by the provided batch number or tag.
-            content:
-              application/json:
-                schema:
-                  $ref: '../evm_responses.yaml#/zkevm_getBatchByNumber'
+                $ref: '../evm_responses.yaml#/zkevm_getBatchByNumber'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_getBroadcastURI.yaml
+++ b/polygon-zkevm/zkevm_getBroadcastURI.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_getBroadcastURI - Polygon zkEVM
         description: Returns the configured Broadcast URL of the Trusted Sequencer.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Returns the configured Broadcast URL of the Trusted Sequencer.
           content:

--- a/polygon-zkevm/zkevm_getBroadcastURI.yaml
+++ b/polygon-zkevm/zkevm_getBroadcastURI.yaml
@@ -13,31 +13,27 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-getBroadcastURI-polygon-zkevm
-        summary: zkevm_getBroadcastURI - Polygon zkEVM
+    post:
+      summary: zkevm_getBroadcastURI - Polygon zkEVM
+      description: Returns the configured Broadcast URL of the Trusted Sequencer.
+      operationId: zkevm-getBroadcastURI-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
         description: Returns the configured Broadcast URL of the Trusted Sequencer.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/zkevm_getBroadcastURI'
+      responses:
+        '200':
           description: Returns the configured Broadcast URL of the Trusted Sequencer.
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/zkevm_getBroadcastURI'
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns the configured Broadcast URL of the Trusted Sequencer.
-            content:
-              application/json:
-                schema:
-                  $ref: '../evm_responses.yaml#/zkevm_getBroadcastURI'
+                $ref: '../evm_responses.yaml#/zkevm_getBroadcastURI'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_isBlockConsolidated.yaml
+++ b/polygon-zkevm/zkevm_isBlockConsolidated.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_isBlockConsolidated - Polygon zkEVM
         description: Returns true if the provided block number is already connected to a batch that was already verified, otherwise false.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Returns true if the provided block number is already connected to a batch that was already verified, otherwise false.
           content:

--- a/polygon-zkevm/zkevm_isBlockConsolidated.yaml
+++ b/polygon-zkevm/zkevm_isBlockConsolidated.yaml
@@ -13,31 +13,27 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-isBlockConsolidated-polygon-zkevm
-        summary: zkevm_isBlockConsolidated - Polygon zkEVM
+    post:
+      summary: zkevm_isBlockConsolidated - Polygon zkEVM
+      description: Returns true if the provided block number is already connected to a batch that was already verified, otherwise false.
+      operationId: zkevm-isBlockConsolidated-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
         description: Returns true if the provided block number is already connected to a batch that was already verified, otherwise false.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/zkevm_isBlockConsolidated
+      responses:
+        '200':
           description: Returns true if the provided block number is already connected to a batch that was already verified, otherwise false.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/zkevm_isBlockConsolidated
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns true if the provided block number is already connected to a batch that was already verified, otherwise false.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/zkevm_isBlockConsolidated
+                $ref: ../evm_responses.yaml#/zkevm_isBlockConsolidated
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_isBlockVirtualized.yaml
+++ b/polygon-zkevm/zkevm_isBlockVirtualized.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_isBlockVirtualized - Polygon zkEVM
         description: Returns true if the provided block number is already connected to a batch that was already virtualized, otherwise false.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Returns true if the provided block number is already connected to a batch that was already virtualized, otherwise false.
           content:

--- a/polygon-zkevm/zkevm_isBlockVirtualized.yaml
+++ b/polygon-zkevm/zkevm_isBlockVirtualized.yaml
@@ -13,31 +13,27 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-isBlockVirtualized-polygon-zkevm
-        summary: zkevm_isBlockVirtualized - Polygon zkEVM
+    post:
+      summary: zkevm_isBlockVirtualized - Polygon zkEVM
+      description: Returns true if the provided block number is already connected to a batch that was already virtualized, otherwise false.
+      operationId: zkevm-isBlockVirtualized-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
         description: Returns true if the provided block number is already connected to a batch that was already virtualized, otherwise false.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/zkevm_isBlockVirtualized
+      responses:
+        '200':
           description: Returns true if the provided block number is already connected to a batch that was already virtualized, otherwise false.
           content:
             application/json:
               schema:
-                $ref: ../evm_body.yaml#/zkevm_isBlockVirtualized
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns true if the provided block number is already connected to a batch that was already virtualized, otherwise false.
-            content:
-              application/json:
-                schema:
-                  $ref: ../evm_responses.yaml#/zkevm_isBlockVirtualized
+                $ref: ../evm_responses.yaml#/zkevm_isBlockVirtualized
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_verifiedBatchNumber.yaml
+++ b/polygon-zkevm/zkevm_verifiedBatchNumber.yaml
@@ -13,30 +13,26 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-verifiedBatchNumber-polygon-zkevm
-        summary: zkevm_verifiedBatchNumber - Polygon zkEVM
-        description: Returns the latest verified batch number.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: zkevm_verifiedBatchNumber - Polygon zkEVM
+      description: Returns the latest verified batch number.
+      operationId: zkevm-verifiedBatchNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/zkevm_verifiedBatchNumber'
+      responses:
+        '200':
+          description: Returns the latest verified batch number.
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/zkevm_verifiedBatchNumber'
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns the latest verified batch number.
-            content:
-              application/json:
-                schema:
-                  $ref: '../evm_responses.yaml#/zkevm_verifiedBatchNumber'
+                $ref: '../evm_responses.yaml#/zkevm_verifiedBatchNumber'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_verifiedBatchNumber.yaml
+++ b/polygon-zkevm/zkevm_verifiedBatchNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_verifiedBatchNumber - Polygon zkEVM
         description: Returns the latest verified batch number.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/polygon-zkevm/zkevm_virtualBatchNumber.yaml
+++ b/polygon-zkevm/zkevm_virtualBatchNumber.yaml
@@ -13,30 +13,26 @@ servers:
         default: polygonzkevm-testnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: zkevm-virtualBatchNumber-polygon-zkevm
-        summary: zkevm_virtualBatchNumber - Polygon zkEVM
-        description: Returns the latest virtual batch number.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
+    post:
+      summary: zkevm_virtualBatchNumber - Polygon zkEVM
+      description: Returns the latest virtual batch number.
+      operationId: zkevm-virtualBatchNumber-polygon-zkevm
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '../evm_body.yaml#/zkevm_virtualBatchNumber'
+      responses:
+        '200':
+          description: Returns the latest virtual batch number.
           content:
             application/json:
               schema:
-                $ref: '../evm_body.yaml#/zkevm_virtualBatchNumber'
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: Returns the latest virtual batch number.
-            content:
-              application/json:
-                schema:
-                  $ref: '../evm_responses.yaml#/zkevm_virtualBatchNumber'
+                $ref: '../evm_responses.yaml#/zkevm_virtualBatchNumber'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/polygon-zkevm/zkevm_virtualBatchNumber.yaml
+++ b/polygon-zkevm/zkevm_virtualBatchNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: zkevm_virtualBatchNumber - Polygon zkEVM
         description: Returns the latest virtual batch number.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           content:
             application/json:

--- a/solana/getAccountInfo.yaml
+++ b/solana/getAccountInfo.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getAccountInfo
       description: Returns all information associated with the account of provided Pubkey.
-      tags: []
+      operationId: getAccountInfo
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getAccountInfo
-      operationId: getAccountInfo
       x-readme:
         explorer-enabled: false

--- a/solana/getAccountInfo.yaml
+++ b/solana/getAccountInfo.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getAccountInfo
       description: Returns all information associated with the account of provided Pubkey.
       operationId: getAccountInfo

--- a/solana/getAccountInfo.yaml
+++ b/solana/getAccountInfo.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns all information associated with the account of provided Pubkey.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBalance.yaml
+++ b/solana/getBalance.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBalance
       description: Returns the balance of the account of provided Pubkey.
       operationId: getBalance

--- a/solana/getBalance.yaml
+++ b/solana/getBalance.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the balance of the account of provided Pubkey.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBalance.yaml
+++ b/solana/getBalance.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBalance
       description: Returns the balance of the account of provided Pubkey.
-      tags: []
+      operationId: getBalance
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBalance
-      operationId: getBalance
       x-readme:
         explorer-enabled: false

--- a/solana/getBlock.yaml
+++ b/solana/getBlock.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlock
       description: Returns identity and transaction information about a confirmed block in the ledger.
       operationId: getBlock

--- a/solana/getBlock.yaml
+++ b/solana/getBlock.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns identity and transaction information about a confirmed block in the ledger.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlock.yaml
+++ b/solana/getBlock.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlock
       description: Returns identity and transaction information about a confirmed block in the ledger.
-      tags: []
+      operationId: getBlock
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlock
-      operationId: getBlock
       x-readme:
         explorer-enabled: false

--- a/solana/getBlockCommitment.yaml
+++ b/solana/getBlockCommitment.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlockCommitment
       description: Returns commitment for particular block.
-      tags: []
+      operationId: getBlockCommitment
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlockCommitment
-      operationId: getBlockCommitment

--- a/solana/getBlockCommitment.yaml
+++ b/solana/getBlockCommitment.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlockCommitment
       description: Returns commitment for particular block.
       operationId: getBlockCommitment

--- a/solana/getBlockCommitment.yaml
+++ b/solana/getBlockCommitment.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns commitment for particular block.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlockHeight.yaml
+++ b/solana/getBlockHeight.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the current block height of the node.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlockHeight.yaml
+++ b/solana/getBlockHeight.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlockHeight
       description: Returns the current block height of the node.
-      tags: []
+      operationId: getBlockHeight
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlockHeight
-      operationId: getBlockHeight

--- a/solana/getBlockHeight.yaml
+++ b/solana/getBlockHeight.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlockHeight
       description: Returns the current block height of the node.
       operationId: getBlockHeight

--- a/solana/getBlockProduction.yaml
+++ b/solana/getBlockProduction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns recent block production information from the current or previous epoch.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlockProduction.yaml
+++ b/solana/getBlockProduction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlockProduction
       description: Returns recent block production information from the current or previous epoch.
-      tags: []
+      operationId: getBlockProduction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlockProduction
-      operationId: getBlockProduction

--- a/solana/getBlockProduction.yaml
+++ b/solana/getBlockProduction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlockProduction
       description: Returns recent block production information from the current or previous epoch.
       operationId: getBlockProduction

--- a/solana/getBlockTime.yaml
+++ b/solana/getBlockTime.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the estimated production time of a block.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlockTime.yaml
+++ b/solana/getBlockTime.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlockTime
       description: Returns the estimated production time of a block.
-      tags: []
+      operationId: getBlockTime
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlockTime
-      operationId: getBlockTime

--- a/solana/getBlockTime.yaml
+++ b/solana/getBlockTime.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlockTime
       description: Returns the estimated production time of a block.
       operationId: getBlockTime

--- a/solana/getBlocks.yaml
+++ b/solana/getBlocks.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns a list of confirmed blocks between two slots.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlocks.yaml
+++ b/solana/getBlocks.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlocks
       description: Returns a list of confirmed blocks between two slots.
       operationId: getBlocks

--- a/solana/getBlocks.yaml
+++ b/solana/getBlocks.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlocks
       description: Returns a list of confirmed blocks between two slots.
-      tags: []
+      operationId: getBlocks
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlocks
-      operationId: getBlocks
       x-readme:
         explorer-enabled: false

--- a/solana/getBlocksWithLimit.yaml
+++ b/solana/getBlocksWithLimit.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns a list of confirmed blocks starting at the given slot.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getBlocksWithLimit.yaml
+++ b/solana/getBlocksWithLimit.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getBlocksWithLimit
       description: Returns a list of confirmed blocks starting at the given slot.
-      tags: []
+      operationId: getBlocksWithLimit
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getBlocks
-      operationId: getBlocksWithLimit
       x-readme:
         explorer-enabled: false

--- a/solana/getBlocksWithLimit.yaml
+++ b/solana/getBlocksWithLimit.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getBlocksWithLimit
       description: Returns a list of confirmed blocks starting at the given slot.
       operationId: getBlocksWithLimit

--- a/solana/getClusterNodes.yaml
+++ b/solana/getClusterNodes.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns information about all the nodes participating in the cluster.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getClusterNodes.yaml
+++ b/solana/getClusterNodes.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getClusterNodes
       description: Returns information about all the nodes participating in the cluster.
-      tags: []
+      operationId: getClusterNodes
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getClusterNodes
-      operationId: getClusterNodes

--- a/solana/getClusterNodes.yaml
+++ b/solana/getClusterNodes.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getClusterNodes
       description: Returns information about all the nodes participating in the cluster.
       operationId: getClusterNodes

--- a/solana/getEpochInfo.yaml
+++ b/solana/getEpochInfo.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns information about the current epoch.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getEpochInfo.yaml
+++ b/solana/getEpochInfo.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getEpochInfo
       description: Returns information about the current epoch.
-      tags: []
+      operationId: getEpochInfo
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getEpochInfo
-      operationId: getEpochInfo

--- a/solana/getEpochInfo.yaml
+++ b/solana/getEpochInfo.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getEpochInfo
       description: Returns information about the current epoch.
       operationId: getEpochInfo

--- a/solana/getEpochSchedule.yaml
+++ b/solana/getEpochSchedule.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getEpochSchedule
       description: Returns epoch schedule information from this cluster's genesis config.
-      tags: []
+      operationId: getEpochSchedule
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getEpochSchedule
-      operationId: getEpochSchedule

--- a/solana/getEpochSchedule.yaml
+++ b/solana/getEpochSchedule.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getEpochSchedule
       description: Returns epoch schedule information from this cluster's genesis config.
       operationId: getEpochSchedule

--- a/solana/getEpochSchedule.yaml
+++ b/solana/getEpochSchedule.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns epoch schedule information from this cluster's genesis config.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getFeeForMessage.yaml
+++ b/solana/getFeeForMessage.yaml
@@ -17,19 +17,7 @@ paths:
       description: Get the fee the network will charge for a particular message.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getFeeForMessage.yaml
+++ b/solana/getFeeForMessage.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getFeeForMessage
       description: Get the fee the network will charge for a particular message.
-      tags: []
+      operationId: getFeeForMessage
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getFeeForMessage
-      operationId: getFeeForMessage
       x-readme:
         explorer-enabled: false

--- a/solana/getFeeForMessage.yaml
+++ b/solana/getFeeForMessage.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getFeeForMessage
       description: Get the fee the network will charge for a particular message.
       operationId: getFeeForMessage

--- a/solana/getFirstAvailableBlock.yaml
+++ b/solana/getFirstAvailableBlock.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getFirstAvailableBlock
       description: Get the fee the network will charge for a particular message.
       operationId: getFirstAvailableBlock

--- a/solana/getFirstAvailableBlock.yaml
+++ b/solana/getFirstAvailableBlock.yaml
@@ -17,19 +17,7 @@ paths:
       description: Get the fee the network will charge for a particular message.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getFirstAvailableBlock.yaml
+++ b/solana/getFirstAvailableBlock.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getFirstAvailableBlock
       description: Get the fee the network will charge for a particular message.
-      tags: []
+      operationId: getFirstAvailableBlock
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getFirstAvailableBlock
-      operationId: getFirstAvailableBlock

--- a/solana/getGenesisHash.yaml
+++ b/solana/getGenesisHash.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getGenesisHash
       description: Returns the genesis hash.
-      tags: []
+      operationId: getGenesisHash
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getGenesisHash
-      operationId: getGenesisHash

--- a/solana/getGenesisHash.yaml
+++ b/solana/getGenesisHash.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the genesis hash.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getGenesisHash.yaml
+++ b/solana/getGenesisHash.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getGenesisHash
       description: Returns the genesis hash.
       operationId: getGenesisHash

--- a/solana/getHealth.yaml
+++ b/solana/getHealth.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the current health of the node.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getHealth.yaml
+++ b/solana/getHealth.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getHealth
       description: Returns the current health of the node.
       operationId: getHealth

--- a/solana/getHealth.yaml
+++ b/solana/getHealth.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getHealth
       description: Returns the current health of the node.
-      tags: []
+      operationId: getHealth
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getHealth
-      operationId: getHealth

--- a/solana/getHighestSnapshotSlot.yaml
+++ b/solana/getHighestSnapshotSlot.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getHighestSnapshotSlot
       description: Returns the highest slot information that the node has snapshots for.
       operationId: getHighestSnapshotSlot

--- a/solana/getHighestSnapshotSlot.yaml
+++ b/solana/getHighestSnapshotSlot.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the highest slot information that the node has snapshots for.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getHighestSnapshotSlot.yaml
+++ b/solana/getHighestSnapshotSlot.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getHighestSnapshotSlot
       description: Returns the highest slot information that the node has snapshots for.
-      tags: []
+      operationId: getHighestSnapshotSlot
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getHighestSnapshotSlot
-      operationId: getHighestSnapshotSlot

--- a/solana/getIdentity.yaml
+++ b/solana/getIdentity.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the identity pubkey for the current node.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getIdentity.yaml
+++ b/solana/getIdentity.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getIdentity
       description: Returns the identity pubkey for the current node.
       operationId: getIdentity

--- a/solana/getIdentity.yaml
+++ b/solana/getIdentity.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getIdentity
       description: Returns the identity pubkey for the current node.
-      tags: []
+      operationId: getIdentity
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getIdentity
-      operationId: getIdentity

--- a/solana/getInflationGovernor.yaml
+++ b/solana/getInflationGovernor.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the current inflation governor.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getInflationGovernor.yaml
+++ b/solana/getInflationGovernor.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getInflationGovernor
       description: Returns the current inflation governor.
       operationId: getInflationGovernor

--- a/solana/getInflationGovernor.yaml
+++ b/solana/getInflationGovernor.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getInflationGovernor
       description: Returns the current inflation governor.
-      tags: []
+      operationId: getInflationGovernor
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getInflationGovernor
-      operationId: getInflationGovernor

--- a/solana/getInflationRate.yaml
+++ b/solana/getInflationRate.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getInflationRate
       description: Returns the specific inflation values for the current epoch.
-      tags: []
+      operationId: getInflationRate
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getInflationRate
-      operationId: getInflationRate

--- a/solana/getInflationRate.yaml
+++ b/solana/getInflationRate.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getInflationRate
       description: Returns the specific inflation values for the current epoch.
       operationId: getInflationRate

--- a/solana/getInflationRate.yaml
+++ b/solana/getInflationRate.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the specific inflation values for the current epoch.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getInflationReward.yaml
+++ b/solana/getInflationReward.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getInflationReward
       description: Returns the inflation / staking reward for a list of addresses for an epoch.
       operationId: getInflationReward

--- a/solana/getInflationReward.yaml
+++ b/solana/getInflationReward.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the inflation / staking reward for a list of addresses for an epoch.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getInflationReward.yaml
+++ b/solana/getInflationReward.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getInflationReward
       description: Returns the inflation / staking reward for a list of addresses for an epoch.
-      tags: []
+      operationId: getInflationReward
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getInflationReward
-      operationId: getInflationReward
       x-readme:
         explorer-enabled: false

--- a/solana/getLargestAccounts.yaml
+++ b/solana/getLargestAccounts.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the 20 largest accounts, by lamport balance (results may be cached up to two hours).
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getLargestAccounts.yaml
+++ b/solana/getLargestAccounts.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getLargestAccounts
       description: Returns the 20 largest accounts, by lamport balance (results may be cached up to two hours).
-      tags: []
+      operationId: getLargestAccounts
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getLargestAccounts
-      operationId: getLargestAccounts

--- a/solana/getLargestAccounts.yaml
+++ b/solana/getLargestAccounts.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getLargestAccounts
       description: Returns the 20 largest accounts, by lamport balance (results may be cached up to two hours).
       operationId: getLargestAccounts

--- a/solana/getMaxRetransmitSlot.yaml
+++ b/solana/getMaxRetransmitSlot.yaml
@@ -17,19 +17,7 @@ paths:
       description: Get the max slot seen from retransmit stage.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getMaxRetransmitSlot.yaml
+++ b/solana/getMaxRetransmitSlot.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getMaxRetransmitSlot
       description: Get the max slot seen from retransmit stage.
-      tags: []
+      operationId: getMaxRetransmitSlot
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getMaxRetransmitSlot
-      operationId: getMaxRetransmitSlot

--- a/solana/getMaxRetransmitSlot.yaml
+++ b/solana/getMaxRetransmitSlot.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getMaxRetransmitSlot
       description: Get the max slot seen from retransmit stage.
       operationId: getMaxRetransmitSlot

--- a/solana/getMaxShredInsertSlot.yaml
+++ b/solana/getMaxShredInsertSlot.yaml
@@ -17,19 +17,7 @@ paths:
       description: Get the max slot seen from after shred insert..
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getMaxShredInsertSlot.yaml
+++ b/solana/getMaxShredInsertSlot.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getMaxShredInsertSlot
       description: Get the max slot seen from after shred insert..
-      tags: []
+      operationId: getMaxShredInsertSlot
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getMaxRetransmitSlot
-      operationId: getMaxShredInsertSlot

--- a/solana/getMaxShredInsertSlot.yaml
+++ b/solana/getMaxShredInsertSlot.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getMaxShredInsertSlot
       description: Get the max slot seen from after shred insert..
       operationId: getMaxShredInsertSlot

--- a/solana/getMinimumBalanceForRentExemption.yaml
+++ b/solana/getMinimumBalanceForRentExemption.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getMinimumBalanceForRentExemption
       description: Returns minimum balance required to make account rent exempt.
-      tags: []
+      operationId: getMinimumBalanceForRentExemption
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getMinimumBalanceForRentExemption
-      operationId: getMinimumBalanceForRentExemption
       x-readme:
         explorer-enabled: false

--- a/solana/getMinimumBalanceForRentExemption.yaml
+++ b/solana/getMinimumBalanceForRentExemption.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getMinimumBalanceForRentExemption
       description: Returns minimum balance required to make account rent exempt.
       operationId: getMinimumBalanceForRentExemption

--- a/solana/getMinimumBalanceForRentExemption.yaml
+++ b/solana/getMinimumBalanceForRentExemption.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns minimum balance required to make account rent exempt.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getMultipleAccounts.yaml
+++ b/solana/getMultipleAccounts.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getMultipleAccounts
       description: Returns the account information for a list of Pubkeys.
-      tags: []
+      operationId: getMultipleAccounts
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getMultipleAccounts
-      operationId: getMultipleAccounts
       x-readme:
         explorer-enabled: false

--- a/solana/getMultipleAccounts.yaml
+++ b/solana/getMultipleAccounts.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the account information for a list of Pubkeys.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getMultipleAccounts.yaml
+++ b/solana/getMultipleAccounts.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getMultipleAccounts
       description: Returns the account information for a list of Pubkeys.
       operationId: getMultipleAccounts

--- a/solana/getProgramAccounts.yaml
+++ b/solana/getProgramAccounts.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getProgramAccounts
       description: Returns all accounts owned by the provided program Pubkey.
-      tags: []
+      operationId: getProgramAccounts
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getProgramAccounts
-      operationId: getProgramAccounts
       x-readme:
         explorer-enabled: false

--- a/solana/getProgramAccounts.yaml
+++ b/solana/getProgramAccounts.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getProgramAccounts
       description: Returns all accounts owned by the provided program Pubkey.
       operationId: getProgramAccounts

--- a/solana/getProgramAccounts.yaml
+++ b/solana/getProgramAccounts.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns all accounts owned by the provided program Pubkey.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getRecentPerformanceSamples.yaml
+++ b/solana/getRecentPerformanceSamples.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and include the number of transactions and slots that occur in a given time window.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getRecentPerformanceSamples.yaml
+++ b/solana/getRecentPerformanceSamples.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getRecentPerformanceSamples
       description: Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and include the number of transactions and slots that occur in a given time window.
       operationId: getRecentPerformanceSamples

--- a/solana/getRecentPerformanceSamples.yaml
+++ b/solana/getRecentPerformanceSamples.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getRecentPerformanceSamples
       description: Returns a list of recent performance samples, in reverse slot order. Performance samples are taken every 60 seconds and include the number of transactions and slots that occur in a given time window.
-      tags: []
+      operationId: getRecentPerformanceSamples
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getRecentPerformanceSamples
-      operationId: getRecentPerformanceSamples

--- a/solana/getSignatureStatuses.yaml
+++ b/solana/getSignatureStatuses.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getSignatureStatuses
       description: Returns the statuses of a list of signatures.
-      tags: []
+      operationId: getSignatureStatuses
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getSignatureStatuses
-      operationId: getSignatureStatuses
       x-readme:
         explorer-enabled: false

--- a/solana/getSignatureStatuses.yaml
+++ b/solana/getSignatureStatuses.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getSignatureStatuses
       description: Returns the statuses of a list of signatures.
       operationId: getSignatureStatuses

--- a/solana/getSignatureStatuses.yaml
+++ b/solana/getSignatureStatuses.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the statuses of a list of signatures.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getSignaturesForAddress.yaml
+++ b/solana/getSignaturesForAddress.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getSignaturesForAddress
       description: Returns signatures for confirmed transactions that include the given address in their accountKeys list. Returns signatures backwards in time from the provided signature or most recent confirmed block.
       operationId: getSignaturesForAddress

--- a/solana/getSignaturesForAddress.yaml
+++ b/solana/getSignaturesForAddress.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getSignaturesForAddress
       description: Returns signatures for confirmed transactions that include the given address in their accountKeys list. Returns signatures backwards in time from the provided signature or most recent confirmed block.
-      tags: []
+      operationId: getSignaturesForAddress
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getSignaturesForAddress
-      operationId: getSignaturesForAddress
       x-readme:
         explorer-enabled: false

--- a/solana/getSignaturesForAddress.yaml
+++ b/solana/getSignaturesForAddress.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns signatures for confirmed transactions that include the given address in their accountKeys list. Returns signatures backwards in time from the provided signature or most recent confirmed block.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getSlot.yaml
+++ b/solana/getSlot.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the slot that has reached the given or default commitment level.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getSlot.yaml
+++ b/solana/getSlot.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getSlot
       description: Returns the slot that has reached the given or default commitment level.
-      tags: []
+      operationId: getSlot
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getSlot
-      operationId: getSlot

--- a/solana/getSlot.yaml
+++ b/solana/getSlot.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getSlot
       description: Returns the slot that has reached the given or default commitment level.
       operationId: getSlot

--- a/solana/getSlotLeader.yaml
+++ b/solana/getSlotLeader.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the current slot leader.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getSlotLeader.yaml
+++ b/solana/getSlotLeader.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getSlotLeader
       description: Returns the current slot leader.
-      tags: []
+      operationId: getSlotLeader
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getSlotLeader
-      operationId: getSlotLeader

--- a/solana/getSlotLeader.yaml
+++ b/solana/getSlotLeader.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getSlotLeader
       description: Returns the current slot leader.
       operationId: getSlotLeader

--- a/solana/getSlotLeaders.yaml
+++ b/solana/getSlotLeaders.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the slot leaders for a given slot range.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getSlotLeaders.yaml
+++ b/solana/getSlotLeaders.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getSlotLeaders
       description: Returns the slot leaders for a given slot range.
       operationId: getSlotLeaders

--- a/solana/getSlotLeaders.yaml
+++ b/solana/getSlotLeaders.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getSlotLeaders
       description: Returns the slot leaders for a given slot range.
-      tags: []
+      operationId: getSlotLeaders
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getSlotLeaders
-      operationId: getSlotLeaders

--- a/solana/getSupply.yaml
+++ b/solana/getSupply.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns information about the current supply.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getSupply.yaml
+++ b/solana/getSupply.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getSupply
       description: Returns information about the current supply.
       operationId: getSupply

--- a/solana/getSupply.yaml
+++ b/solana/getSupply.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getSupply
       description: Returns information about the current supply.
-      tags: []
+      operationId: getSupply
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getSupply
-      operationId: getSupply

--- a/solana/getTokenAccountBalance.yaml
+++ b/solana/getTokenAccountBalance.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getTokenAccountBalance
       description: Returns the token balance of an SPL Token account..
-      tags: []
+      operationId: getTokenAccountBalance
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getTokenAccountBalance
-      operationId: getTokenAccountBalance
       x-readme:
         explorer-enabled: false

--- a/solana/getTokenAccountBalance.yaml
+++ b/solana/getTokenAccountBalance.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getTokenAccountBalance
       description: Returns the token balance of an SPL Token account..
       operationId: getTokenAccountBalance

--- a/solana/getTokenAccountBalance.yaml
+++ b/solana/getTokenAccountBalance.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the token balance of an SPL Token account..
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getTokenAccountsByOwner.yaml
+++ b/solana/getTokenAccountsByOwner.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getTokenAccountsByOwner
       description: Returns all SPL Token accounts by token owner.
-      tags: []
+      operationId: getTokenAccountsByOwner
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getTokenAccountsByOwner
-      operationId: getTokenAccountsByOwner
       x-readme:
         explorer-enabled: false

--- a/solana/getTokenAccountsByOwner.yaml
+++ b/solana/getTokenAccountsByOwner.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns all SPL Token accounts by token owner.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getTokenAccountsByOwner.yaml
+++ b/solana/getTokenAccountsByOwner.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getTokenAccountsByOwner
       description: Returns all SPL Token accounts by token owner.
       operationId: getTokenAccountsByOwner

--- a/solana/getTokenSupply.yaml
+++ b/solana/getTokenSupply.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the total supply of an SPL Token type.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getTokenSupply.yaml
+++ b/solana/getTokenSupply.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getTokenSupply
       description: Returns the total supply of an SPL Token type.
-      tags: []
+      operationId: getTokenSupply
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getTokenSupply
-      operationId: getTokenSupply
       x-readme:
         explorer-enabled: false

--- a/solana/getTokenSupply.yaml
+++ b/solana/getTokenSupply.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getTokenSupply
       description: Returns the total supply of an SPL Token type.
       operationId: getTokenSupply

--- a/solana/getTransaction.yaml
+++ b/solana/getTransaction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns transaction details for a confirmed transaction.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getTransaction.yaml
+++ b/solana/getTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getTransaction
       description: Returns transaction details for a confirmed transaction.
       operationId: getTransaction

--- a/solana/getTransaction.yaml
+++ b/solana/getTransaction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getTransaction
       description: Returns transaction details for a confirmed transaction.
-      tags: []
+      operationId: getTransaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getTransaction
-      operationId: getTransaction
       x-readme:
         explorer-enabled: false

--- a/solana/getVersion.yaml
+++ b/solana/getVersion.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getVersion
       description: Returns the current solana versions running on the node.
-      tags: []
+      operationId: getVersion
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getVersion
-      operationId: getVersion

--- a/solana/getVersion.yaml
+++ b/solana/getVersion.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the current solana versions running on the node.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getVersion.yaml
+++ b/solana/getVersion.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getVersion
       description: Returns the current solana versions running on the node.
       operationId: getVersion

--- a/solana/getVoteAccounts.yaml
+++ b/solana/getVoteAccounts.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: getVoteAccounts
       description: Returns the account info and associated stake for all the voting accounts in the current bank.
-      tags: []
+      operationId: getVoteAccounts
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/getVoteAccounts
-      operationId: getVoteAccounts

--- a/solana/getVoteAccounts.yaml
+++ b/solana/getVoteAccounts.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the account info and associated stake for all the voting accounts in the current bank.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/getVoteAccounts.yaml
+++ b/solana/getVoteAccounts.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: getVoteAccounts
       description: Returns the account info and associated stake for all the voting accounts in the current bank.
       operationId: getVoteAccounts

--- a/solana/isBlockhashValid.yaml
+++ b/solana/isBlockhashValid.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: isBlockhashValid
       description: Returns whether a blockhash is still valid or not.
-      tags: []
+      operationId: isBlockhashValid
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/isBlockhashValid
-      operationId: isBlockhashValid
       x-readme:
         explorer-enabled: false

--- a/solana/isBlockhashValid.yaml
+++ b/solana/isBlockhashValid.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: isBlockhashValid
       description: Returns whether a blockhash is still valid or not.
       operationId: isBlockhashValid

--- a/solana/isBlockhashValid.yaml
+++ b/solana/isBlockhashValid.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns whether a blockhash is still valid or not.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/minimumLedgerSlot.yaml
+++ b/solana/minimumLedgerSlot.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns the lowest slot that the node has information about in its ledger. This value may increase over time if the node is configured to purge older ledger data.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/minimumLedgerSlot.yaml
+++ b/solana/minimumLedgerSlot.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: minimumLedgerSlot
       description: Returns the lowest slot that the node has information about in its ledger. This value may increase over time if the node is configured to purge older ledger data.
       operationId: minimumLedgerSlot

--- a/solana/minimumLedgerSlot.yaml
+++ b/solana/minimumLedgerSlot.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: minimumLedgerSlot
       description: Returns the lowest slot that the node has information about in its ledger. This value may increase over time if the node is configured to purge older ledger data.
-      tags: []
+      operationId: minimumLedgerSlot
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/minimumLedgerSlot
-      operationId: minimumLedgerSlot

--- a/solana/requestAirdrop.yaml
+++ b/solana/requestAirdrop.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: requestAirdrop
       description: Requests an airdrop of lamports to a Pubkey
       operationId: requestAirdrop

--- a/solana/requestAirdrop.yaml
+++ b/solana/requestAirdrop.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: requestAirdrop
       description: Requests an airdrop of lamports to a Pubkey
-      tags: []
+      operationId: requestAirdrop
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -23,12 +24,6 @@ paths:
           application/json:
             schema:
               $ref: solana_body.yaml#/requestAirdrop
-      x-readme:
-        explorer-enabled: false
-        samples-languages:
-          - curl
-          - javascript
-          - python
         code-samples:
           - language: shell
             name: cURL
@@ -49,4 +44,9 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/requestAirdrop
-      operationId: requestAirdrop
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/solana/requestAirdrop.yaml
+++ b/solana/requestAirdrop.yaml
@@ -17,19 +17,7 @@ paths:
       description: Requests an airdrop of lamports to a Pubkey
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/sendTransaction.yaml
+++ b/solana/sendTransaction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: sendTransaction
       description: Submits a signed transaction to the cluster for processing.
-      tags: []
+      operationId: sendTransaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/sendTransaction
-      operationId: sendTransaction
       x-readme:
         explorer-enabled: false

--- a/solana/sendTransaction.yaml
+++ b/solana/sendTransaction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Submits a signed transaction to the cluster for processing.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/solana/sendTransaction.yaml
+++ b/solana/sendTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: sendTransaction
       description: Submits a signed transaction to the cluster for processing.
       operationId: sendTransaction

--- a/solana/simulateTransaction.yaml
+++ b/solana/simulateTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: simulateTransaction
       description: Simulate sending a transaction.
       operationId: simulateTransaction

--- a/solana/simulateTransaction.yaml
+++ b/solana/simulateTransaction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: simulateTransaction
       description: Simulate sending a transaction.
-      tags: []
+      operationId: simulateTransaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,6 +31,5 @@ paths:
             application/json:
               schema:
                 $ref: solana_responses.yaml#/simulateTransaction
-      operationId: simulateTransaction
       x-readme:
         explorer-enabled: false

--- a/solana/simulateTransaction.yaml
+++ b/solana/simulateTransaction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Simulate sending a transaction.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/starknet/starknet_addDeclareTransaction.yaml
+++ b/starknet/starknet_addDeclareTransaction.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_addDeclareTransaction
         description: Submit a new class declaration transaction
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_addDeclareTransaction.yaml
+++ b/starknet/starknet_addDeclareTransaction.yaml
@@ -13,59 +13,55 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-addDeclareTransaction
-        summary: starknet_addDeclareTransaction
-        description: Submit a new class declaration transaction
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_addDeclareTransaction
+      description: Submit a new class declaration transaction
+      operationId: starknet-addDeclareTransaction
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: 'evm_body.yaml#/common_request_fields' # path only works with gh actions for command line add ../ in the beginning
+                - type: object
+                  properties:
+                    method:
+                      $ref: components/schemas.yaml#/Method # path only works with gh actions for command line add ../ in the beginning
+                      default: starknet_addDeclareTransaction
+                    params:
+                      type: array
+                      title: declare_transaction
+                      items:
+                        $ref: 'components/starknet/schemas.yaml#/BroadcastedDeclareTxn' # path only works with gh actions for command line add ../ in the beginning
+                      description: The declaration transaction to be submitted
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The result of the transaction submission
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: 'evm_body.yaml#/common_request_fields' # path only works with gh actions for command line add ../ in the beginning
+                  - $ref: 'evm_responses.yaml#/common_response_fields' # path only works with gh actions for command line add ../ in the beginning
                   - type: object
                     properties:
-                      method:
-                        $ref: components/schemas.yaml#/Method # path only works with gh actions for command line add ../ in the beginning
-                        default: starknet_addDeclareTransaction
-                      params:
-                        type: array
-                        title: declare_transaction
-                        items:
-                          $ref: 'components/starknet/schemas.yaml#/BroadcastedDeclareTxn' # path only works with gh actions for command line add ../ in the beginning
-                        description: The declaration transaction to be submitted
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The result of the transaction submission
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: 'evm_responses.yaml#/common_response_fields' # path only works with gh actions for command line add ../ in the beginning
-                    - type: object
-                      properties:
-                        result:
-                          type: object
-                          properties:
-                            transactionHash:
-                              title: The hash of the declare transaction
-                              $ref: 'components/starknet/schemas.yaml#/TxnHash' # path only works with gh actions for command line add ../ in the beginning
-                            classHash:
-                              title: The hash of the declared class
-                              $ref: 'components/starknet/schemas.yaml#/Felt' # path only works with gh actions for command line add ../ in the beginning
-                      example:
-                        $ref: 'components/starknet/examples.yaml#/starknet_addDeclareTransaction' # path only works with gh actions for command line add ../ in the beginning
+                      result:
+                        type: object
+                        properties:
+                          transactionHash:
+                            title: The hash of the declare transaction
+                            $ref: 'components/starknet/schemas.yaml#/TxnHash' # path only works with gh actions for command line add ../ in the beginning
+                          classHash:
+                            title: The hash of the declared class
+                            $ref: 'components/starknet/schemas.yaml#/Felt' # path only works with gh actions for command line add ../ in the beginning
+                    example:
+                      $ref: 'components/starknet/examples.yaml#/starknet_addDeclareTransaction' # path only works with gh actions for command line add ../ in the beginning
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_addDeployAccountTransaction.yaml
+++ b/starknet/starknet_addDeployAccountTransaction.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_addDeployAccountTransaction
         description: Submit a new deploy account transaction
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_addDeployAccountTransaction.yaml
+++ b/starknet/starknet_addDeployAccountTransaction.yaml
@@ -13,59 +13,55 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-addDeployAccountTransaction
-        summary: starknet_addDeployAccountTransaction
-        description: Submit a new deploy account transaction
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_addDeployAccountTransaction
+      description: Submit a new deploy account transaction
+      operationId: starknet-addDeployAccountTransaction
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_addDeployAccountTransaction
+                    params:
+                      type: array
+                      title: deploy_account_transaction
+                      items:
+                        $ref: '../components/starknet/schemas.yaml#/BroadcastedDeployAccountTxn'
+                      description: The deploy account transaction
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The result of the transaction submission
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_addDeployAccountTransaction
-                      params:
-                        type: array
-                        title: deploy_account_transaction
-                        items:
-                          $ref: '../components/starknet/schemas.yaml#/BroadcastedDeployAccountTxn'
-                        description: The deploy account transaction
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The result of the transaction submission
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          type: object
-                          properties:
-                            transactionHash:
-                              title: The hash of the deploy transaction
-                              $ref: '../components/starknet/schemas.yaml#/TxnHash'
-                            contractAddress:
-                              title: The address of the new contract
-                              $ref: '../components/starknet/schemas.yaml#/Felt'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_addDeployAccountTransaction'
+                      result:
+                        type: object
+                        properties:
+                          transactionHash:
+                            title: The hash of the deploy transaction
+                            $ref: '../components/starknet/schemas.yaml#/TxnHash'
+                          contractAddress:
+                            title: The address of the new contract
+                            $ref: '../components/starknet/schemas.yaml#/Felt'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_addDeployAccountTransaction'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_addInvokeTransaction.yaml
+++ b/starknet/starknet_addInvokeTransaction.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_addInvokeTransaction
         description: Submit a new transaction to be added to the chain
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_addInvokeTransaction.yaml
+++ b/starknet/starknet_addInvokeTransaction.yaml
@@ -13,58 +13,54 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-addInvokeTransaction
-        summary: starknet_addInvokeTransaction
-        description: Submit a new transaction to be added to the chain
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_addInvokeTransaction
+      description: Submit a new transaction to be added to the chain
+      operationId: starknet-addInvokeTransaction
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_addInvokeTransaction
+                    params:
+                      type: array
+                      title: Parameters
+                      items:
+                        $ref: '../components/starknet/schemas.yaml#/BroadcastedInvokeTxn'
+                        title: invoke_transaction
+                        description: The information needed to invoke the function (or account, for version 1 transactions)
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The result of the transaction submission
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_addInvokeTransaction
-                      params:
-                        type: array
-                        title: Parameters
-                        items:
-                          $ref: '../components/starknet/schemas.yaml#/BroadcastedInvokeTxn'
-                          title: invoke_transaction
-                          description: The information needed to invoke the function (or account, for version 1 transactions)
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The result of the transaction submission
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          type: object
-                          properties:
-                            transaction_hash:
-                              $ref: '../components/starknet/schemas.yaml#/TxnHash'
-                              title: The hash of the invoke transaction
-                              description: The hash of the invoke transaction
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_addInvokeTransaction'
+                      result:
+                        type: object
+                        properties:
+                          transaction_hash:
+                            $ref: '../components/starknet/schemas.yaml#/TxnHash'
+                            title: The hash of the invoke transaction
+                            description: The hash of the invoke transaction
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_addInvokeTransaction'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_blockHashAndNumber.yaml
+++ b/starknet/starknet_blockHashAndNumber.yaml
@@ -13,54 +13,50 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-blockHashAndNumber
-        summary: starknet_blockHashAndNumber
-        description: Get the most recent accepted block hash and number
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_blockHashAndNumber
+      description: Get the most recent accepted block hash and number
+      operationId: starknet-blockHashAndNumber
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_blockHashAndNumber
+                    params:
+                      type: array
+                      title: No parameters required
+                      description: This method does not require any parameters
+      responses:
+        '200':
+          description: The latest block hash and number
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_blockHashAndNumber
-                      params:
-                        type: array
-                        title: No parameters required
-                        description: This method does not require any parameters
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The latest block hash and number
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockHash'
-                              title: Block hash
-                              description: The hash of the most recent accepted block
-                            - $ref: '../components/starknet/schemas.yaml#/BlockNumber'
-                              title: Block number
-                              description: The number of the most recent accepted block
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_blockHashAndNumber'
+                      result:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockHash'
+                            title: Block hash
+                            description: The hash of the most recent accepted block
+                          - $ref: '../components/starknet/schemas.yaml#/BlockNumber'
+                            title: Block number
+                            description: The number of the most recent accepted block
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_blockHashAndNumber'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_blockHashAndNumber.yaml
+++ b/starknet/starknet_blockHashAndNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_blockHashAndNumber
         description: Get the most recent accepted block hash and number
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_blockNumber.yaml
+++ b/starknet/starknet_blockNumber.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_blockNumber
         description: Get the most recent accepted block number
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_blockNumber.yaml
+++ b/starknet/starknet_blockNumber.yaml
@@ -13,48 +13,44 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-blockNumber
-        summary: starknet_blockNumber
-        description: Get the most recent accepted block number
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_blockNumber
+      description: Get the most recent accepted block number
+      operationId: starknet-blockNumber
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_blockNumber
+                    params:
+                      type: array
+                      title: params
+                      description: The method takes no parameters
+      responses:
+        '200':
+          description: The latest block number
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_blockNumber
-                      params:
-                        type: array
-                        title: params
-                        description: The method takes no parameters
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The latest block number
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/BlockNumber'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_blockNumber'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/BlockNumber'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_blockNumber'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_call.yaml
+++ b/starknet/starknet_call.yaml
@@ -13,66 +13,62 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-call
-        summary: starknet_call
-        description: Calls a function in a contract and returns the return value. Using this call will not create a transaction; hence, will not change the state.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_call
+      description: Calls a function in a contract and returns the return value. Using this call will not create a transaction; hence, will not change the state.
+      operationId: starknet-call
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_call
+                    params:
+                      type: array
+                      default:
+                        [
+                          {
+                            'contract_address': '0x049E0cCb70e1F1684F43116e9E42e60D0f64d3D254Be8D8A1143dba43dEad733',
+                            'calldata':
+                              ['0xbfc2ea1a458d7cac752a4a688dbb8e0cff399e1b'],
+                            'entry_point_selector': '0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6',
+                          },
+                          'latest',
+                        ]
+                      title: Params
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/FunctionCall'
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The details of the function call and the block_id for the block referencing the state or call the transaction on.
+                      minItems: 2
+                      maxItems: 2
+      responses:
+        '200':
+          description: The function's return value
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_call
-                      params:
+                      result:
                         type: array
-                        default:
-                          [
-                            {
-                              'contract_address': '0x049E0cCb70e1F1684F43116e9E42e60D0f64d3D254Be8D8A1143dba43dEad733',
-                              'calldata':
-                                ['0xbfc2ea1a458d7cac752a4a688dbb8e0cff399e1b'],
-                              'entry_point_selector': '0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6',
-                            },
-                            'latest',
-                          ]
-                        title: Params
                         items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/FunctionCall'
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The details of the function call and the block_id for the block referencing the state or call the transaction on.
-                        minItems: 2
-                        maxItems: 2
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The function's return value
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          type: array
-                          items:
-                            $ref: '../components/starknet/schemas.yaml#/Felt'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_call'
+                          $ref: '../components/starknet/schemas.yaml#/Felt'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_call'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_call.yaml
+++ b/starknet/starknet_call.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_call
         description: Calls a function in a contract and returns the return value. Using this call will not create a transaction; hence, will not change the state.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_chainId.yaml
+++ b/starknet/starknet_chainId.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_chainId
         description: Return the currently configured StarkNet chain id
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_chainId.yaml
+++ b/starknet/starknet_chainId.yaml
@@ -13,50 +13,46 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-chainId
-        summary: starknet_chainId
-        description: Return the currently configured StarkNet chain id
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_chainId
+      description: Return the currently configured StarkNet chain id
+      operationId: starknet-chainId
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_chainId
+                    params:
+                      type: array
+                      title: No parameters required
+                      description: This method does not require any parameters
+      responses:
+        '200':
+          description: The chain id this node is connected to
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_chainId
-                      params:
-                        type: array
-                        title: No parameters required
-                        description: This method does not require any parameters
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The chain id this node is connected to
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/ChainId'
-                          title: Chain id
-                          description: The chain id this node is connected to
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_chainId'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/ChainId'
+                        title: Chain id
+                        description: The chain id this node is connected to
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_chainId'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_estimateFee.yaml
+++ b/starknet/starknet_estimateFee.yaml
@@ -13,58 +13,54 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-estimateFee
-        summary: starknet_estimateFee
-        description: Estimates the resources required by transactions when applied on a given state.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_estimateFee
+      description: Estimates the resources required by transactions when applied on a given state.
+      operationId: starknet-estimateFee
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_estimateFee
+                    params:
+                      type: array
+                      title: Params
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BroadcastedTxn'
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The transaction to estimate and the block_id for the block referencing the state or call the transaction on.
+                      maxItems: 1
+                      minItems: 1
+      responses:
+        '200':
+          description: The fee estimations
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_estimateFee
-                      params:
+                      result:
                         type: array
-                        title: Params
+                        description: A sequence of fee estimates where the i'th estimate corresponds to the i'th transaction.
                         items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BroadcastedTxn'
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The transaction to estimate and the block_id for the block referencing the state or call the transaction on.
-                        maxItems: 1
-                        minItems: 1
-        x-readme:
-          explorer-enabled: false
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The fee estimations
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          type: array
-                          description: A sequence of fee estimates where the i'th estimate corresponds to the i'th transaction.
-                          items:
-                            $ref: '../components/starknet/schemas.yaml#/FeeEstimate'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_estimateFee'
+                          $ref: '../components/starknet/schemas.yaml#/FeeEstimate'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_estimateFee'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_estimateFee.yaml
+++ b/starknet/starknet_estimateFee.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_estimateFee
         description: Estimates the resources required by transactions when applied on a given state.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_estimateMessageFee.yaml
+++ b/starknet/starknet_estimateMessageFee.yaml
@@ -14,23 +14,11 @@ servers:
 paths:
   /{apiKey}:
     post:
-      operationId: starknet-estimateMessageFee
       summary: starknet_estimateMessageFee
       description: Estimates the resources required by the l1_handler transaction induced by the message
+      operationId: starknet-estimateMessageFee
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-          description: |
-            <style>
-              .custom-style {
-                color: #048FF4;
-              }
-            </style>
-            For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         description: Request Body
         content:
@@ -58,3 +46,9 @@ paths:
             application/json:
               schema:
                 $ref: '../components/starknet/schemas.yaml#/FeeEstimate'
+      x-readme:
+        explorer-enabled: false
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getBlockTransactionCount.yaml
+++ b/starknet/starknet_getBlockTransactionCount.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getBlockTransactionCount
         description: Returns the number of transactions in the designated block.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getBlockTransactionCount.yaml
+++ b/starknet/starknet_getBlockTransactionCount.yaml
@@ -13,54 +13,51 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getBlockTransactionCount
-        summary: starknet_getBlockTransactionCount
-        description: Returns the number of transactions in the designated block.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getBlockTransactionCount
+      description: Returns the number of transactions in the designated block.
+      operationId: starknet-getBlockTransactionCount
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_getBlockTransactionCount
+                    params:
+                      type: array
+                      default: ['latest']
+                      title: Params
+                      items:
+                        - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The hash of the requested block, or number (height) of the requested block, or a block tag
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The number of transactions in the designated block
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_getBlockTransactionCount
-                      params:
-                        type: array
-                        default: ['latest']
-                        title: Params
-                        items:
-                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The hash of the requested block, or number (height) of the requested block, or a block tag
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The number of transactions in the designated block
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          type: integer
-                          minimum: 0
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getBlockTransactionCount'
+                      result:
+                        type: integer
+                        minimum: 0
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getBlockTransactionCount'
+    x-readme:
+      explorer-enabled: false
+      samples-languages:
+        - curl
+        - javascript
+        - python

--- a/starknet/starknet_getBlockWithTxHashes.yaml
+++ b/starknet/starknet_getBlockWithTxHashes.yaml
@@ -13,54 +13,51 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getBlockWithTxHashes
-        summary: starknet_getBlockWithTxHashes
-        description: Get block information with transaction hashes given the block id
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getBlockWithTxHashes
+      description: Get block information with transaction hashes given the block id
+      operationId: starknet-getBlockWithTxHashes
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getBlockWithTxHashes
+                    params:
+                      type: array
+                      title: block_id
+                      items:
+                        $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The hash of the requested block, or number (height) of the requested block, or a block tag
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The resulting block information with transaction hashes
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getBlockWithTxHashes
-                      params:
-                        type: array
-                        title: block_id
-                        items:
-                          $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The hash of the requested block, or number (height) of the requested block, or a block tag
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The resulting block information with transaction hashes
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockWithTxHashes'
-                            - $ref: '../components/starknet/schemas.yaml#/PendingBlockWithTxHashes'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getBlockWithTxHashes'
+                      result:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockWithTxHashes'
+                          - $ref: '../components/starknet/schemas.yaml#/PendingBlockWithTxHashes'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getBlockWithTxHashes'
+    x-readme:
+      explorer-enabled: false
+      samples-languages:
+        - curl
+        - javascript
+        - python

--- a/starknet/starknet_getBlockWithTxHashes.yaml
+++ b/starknet/starknet_getBlockWithTxHashes.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getBlockWithTxHashes
         description: Get block information with transaction hashes given the block id
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getBlockWithTxs.yaml
+++ b/starknet/starknet_getBlockWithTxs.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getBlockWithTxs
         description: Get block information with full transactions given the block id
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getBlockWithTxs.yaml
+++ b/starknet/starknet_getBlockWithTxs.yaml
@@ -13,54 +13,51 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getBlockWithTxs
-        summary: starknet_getBlockWithTxs
-        description: Get block information with full transactions given the block id
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getBlockWithTxs
+      description: Get block information with full transactions given the block id
+      operationId: starknet-getBlockWithTxs
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getBlockWithTxs
+                    params:
+                      type: array
+                      title: block_id
+                      items:
+                        $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The hash of the requested block, or number (height) of the requested block, or a block tag
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The resulting block information with full transactions
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getBlockWithTxs
-                      params:
-                        type: array
-                        title: block_id
-                        items:
-                          $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The hash of the requested block, or number (height) of the requested block, or a block tag
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The resulting block information with full transactions
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockWithTxs'
-                            - $ref: '../components/starknet/schemas.yaml#/PendingBlockWithTxs'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getBlockWithTxs'
+                      result:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockWithTxs'
+                          - $ref: '../components/starknet/schemas.yaml#/PendingBlockWithTxs'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getBlockWithTxs'
+    x-readme:
+      explorer-enabled: false
+      samples-languages:
+        - curl
+        - javascript
+        - python

--- a/starknet/starknet_getClass.yaml
+++ b/starknet/starknet_getClass.yaml
@@ -13,57 +13,54 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getClass
-        summary: starknet_getClass
-        description: Get the contract class definition in the given block associated with the given hash
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getClass
+      description: Get the contract class definition in the given block associated with the given hash
+      operationId: starknet-getClass
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getClass
+                    params:
+                      type: array
+                      title: Params
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                          - $ref: '../components/starknet/schemas.yaml#/Felt'
+                            default: '0x601407cf04ab1fbab155f913db64891dc749f4343bc9e535bd012234a46dc61'
+                      description: The block id of the requested block and the hash of the requested contract class
+                      minItems: 2
+                      maxItems: 2
+      responses:
+        '200':
+          description: The contract class, if found
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getClass
-                      params:
-                        type: array
-                        title: Params
-                        items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                            - $ref: '../components/starknet/schemas.yaml#/Felt'
-                              default: '0x601407cf04ab1fbab155f913db64891dc749f4343bc9e535bd012234a46dc61'
-                        description: The block id of the requested block and the hash of the requested contract class
-                        minItems: 2
-                        maxItems: 2
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The contract class, if found
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/DeprecatedContractClass'
-                            - $ref: '../components/starknet/schemas.yaml#/ContractClass'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getClass'
+                      result:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/DeprecatedContractClass'
+                          - $ref: '../components/starknet/schemas.yaml#/ContractClass'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getClass'
+    x-readme:
+      explorer-enabled: false
+      samples-languages:
+        - curl
+        - javascript
+        - python

--- a/starknet/starknet_getClass.yaml
+++ b/starknet/starknet_getClass.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getClass
         description: Get the contract class definition in the given block associated with the given hash
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getClassAt.yaml
+++ b/starknet/starknet_getClassAt.yaml
@@ -13,56 +13,53 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getClassAt
-        summary: starknet_getClassAt
-        description: Get the contract class definition in the given block at the given address
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getClassAt
+      description: Get the contract class definition in the given block at the given address
+      operationId: starknet-getClassAt
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_getClassAt
+                    params:
+                      type: array
+                      title: Params
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                          - $ref: '../components/starknet/schemas.yaml#/Address'
+                      description: The hash of the requested block and the address of the contract whose class definition will be returned
+                      minItems: 2
+                      maxItems: 2
+      responses:
+        '200':
+          description: The contract class
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_getClassAt
-                      params:
-                        type: array
-                        title: Params
-                        items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                            - $ref: '../components/starknet/schemas.yaml#/Address'
-                        description: The hash of the requested block and the address of the contract whose class definition will be returned
-                        minItems: 2
-                        maxItems: 2
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The contract class
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/DeprecatedContractClass'
-                            - $ref: '../components/starknet/schemas.yaml#/ContractClass'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getClassAt'
+                      result:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/DeprecatedContractClass'
+                          - $ref: '../components/starknet/schemas.yaml#/ContractClass'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getClassAt'
+    x-readme:
+      explorer-enabled: false
+      samples-languages:
+        - curl
+        - javascript
+        - python

--- a/starknet/starknet_getClassAt.yaml
+++ b/starknet/starknet_getClassAt.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getClassAt
         description: Get the contract class definition in the given block at the given address
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getClassHashAt.yaml
+++ b/starknet/starknet_getClassHashAt.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getClassHashAt
         description: Get the contract class hash in the given block for the contract deployed at the given address
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getClassHashAt.yaml
+++ b/starknet/starknet_getClassHashAt.yaml
@@ -13,54 +13,50 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getClassHashAt
-        summary: starknet_getClassHashAt
-        description: Get the contract class hash in the given block for the contract deployed at the given address
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getClassHashAt
+      description: Get the contract class hash in the given block for the contract deployed at the given address
+      operationId: starknet-getClassHashAt
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getClassHashAt
+                    params:
+                      type: array
+                      title: Params
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                          - $ref: '../components/starknet/schemas.yaml#/Address'
+                      description: The hash of the requested block and the address of the contract whose class hash will be returned
+                      minItems: 2
+                      maxItems: 2
+      responses:
+        '200':
+          description: The class hash of the given contract
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getClassHashAt
-                      params:
-                        type: array
-                        title: Params
-                        items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                            - $ref: '../components/starknet/schemas.yaml#/Address'
-                        description: The hash of the requested block and the address of the contract whose class hash will be returned
-                        minItems: 2
-                        maxItems: 2
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The class hash of the given contract
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/Felt'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getClassHashAt'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/Felt'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getClassHashAt'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getEvents.yaml
+++ b/starknet/starknet_getEvents.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getEvents
         description: Returns all event objects matching the conditions in the provided filter
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getEvents.yaml
+++ b/starknet/starknet_getEvents.yaml
@@ -13,65 +13,61 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getEvents
-        summary: starknet_getEvents
-        description: Returns all event objects matching the conditions in the provided filter
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getEvents
+      description: Returns all event objects matching the conditions in the provided filter
+      operationId: starknet-getEvents
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_getEvents
+                    params:
+                      type: array
+                      default:
+                        [
+                          {
+                            'from_block': 'latest',
+                            'to_block': 'latest',
+                            'address': '0x044e5b3f0471a26bc749ffa1d8dd8e43640e05f1b33cf05cef6adee6f5b1b4cf',
+                            'chunk_size': 10,
+                          },
+                        ]
+                      title: filter
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/EventFilter'
+                          - $ref: '../components/starknet/schemas.yaml#/ResultPageRequest'
+                      description: The conditions used to filter the returned events
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: All the event objects matching the filter
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_getEvents
-                      params:
-                        type: array
-                        default:
-                          [
-                            {
-                              'from_block': 'latest',
-                              'to_block': 'latest',
-                              'address': '0x044e5b3f0471a26bc749ffa1d8dd8e43640e05f1b33cf05cef6adee6f5b1b4cf',
-                              'chunk_size': 10,
-                            },
-                          ]
-                        title: filter
-                        items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/EventFilter'
-                            - $ref: '../components/starknet/schemas.yaml#/ResultPageRequest'
-                        description: The conditions used to filter the returned events
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: All the event objects matching the filter
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/EventsChunk'
-                          title: events
-                          description: All the event objects matching the filter
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getEvents'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/EventsChunk'
+                        title: events
+                        description: All the event objects matching the filter
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getEvents'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getNonce.yaml
+++ b/starknet/starknet_getNonce.yaml
@@ -13,59 +13,55 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getNonce
-        summary: starknet_getNonce
-        description: Get the nonce associated with the given address in the given block
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getNonce
+      description: Get the nonce associated with the given address in the given block
+      operationId: starknet-getNonce
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_getNonce
+                    params:
+                      type: array
+                      title: Parameters
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                            title: block_id
+                            description: The hash of the requested block, or number (height) of the requested block, or a block tag
+                          - $ref: '../components/starknet/schemas.yaml#/Address'
+                            title: contract_address
+                            description: The address of the contract whose nonce we're seeking
+                      minItems: 2
+                      maxItems: 2
+      responses:
+        '200':
+          description: The last nonce used for the given contract
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_getNonce
-                      params:
-                        type: array
-                        title: Parameters
-                        items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                              title: block_id
-                              description: The hash of the requested block, or number (height) of the requested block, or a block tag
-                            - $ref: '../components/starknet/schemas.yaml#/Address'
-                              title: contract_address
-                              description: The address of the contract whose nonce we're seeking
-                        minItems: 2
-                        maxItems: 2
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The last nonce used for the given contract
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/Felt'
-                          title: result
-                          description: The last nonce used for the given contract
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getNonce'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/Felt'
+                        title: result
+                        description: The last nonce used for the given contract
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getNonce'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getNonce.yaml
+++ b/starknet/starknet_getNonce.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getNonce
         description: Get the nonce associated with the given address in the given block
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getStateUpdate.yaml
+++ b/starknet/starknet_getStateUpdate.yaml
@@ -13,54 +13,50 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getStateUpdate
-        summary: starknet_getStateUpdate
-        description: Get the information about the result of executing the requested block
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getStateUpdate
+      description: Get the information about the result of executing the requested block
+      operationId: starknet-getStateUpdate
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getStateUpdate
+                    params:
+                      type: array
+                      title: block_id
+                      items:
+                        $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The hash of the requested block, or number (height) of the requested block, or a block tag
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The information about the state update of the requested block
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getStateUpdate
-                      params:
-                        type: array
-                        title: block_id
-                        items:
-                          $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The hash of the requested block, or number (height) of the requested block, or a block tag
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The information about the state update of the requested block
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/StateUpdate'
-                            - $ref: '../components/starknet/schemas.yaml#/PendingStateUpdate'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getStateUpdate'
+                      result:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/StateUpdate'
+                          - $ref: '../components/starknet/schemas.yaml#/PendingStateUpdate'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getStateUpdate'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getStateUpdate.yaml
+++ b/starknet/starknet_getStateUpdate.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getStateUpdate
         description: Get the information about the result of executing the requested block
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getStorageAt.yaml
+++ b/starknet/starknet_getStorageAt.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getStorageAt
         description: Get the value of the storage at the given address and key
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getStorageAt.yaml
+++ b/starknet/starknet_getStorageAt.yaml
@@ -13,60 +13,56 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getStorageAt
-        summary: starknet_getStorageAt
-        description: Get the value of the storage at the given address and key
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getStorageAt
+      description: Get the value of the storage at the given address and key
+      operationId: starknet-getStorageAt
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getStorageAt
+                    params:
+                      type: array
+                      title: Params
+                      items:
+                        - $ref: '../components/starknet/schemas.yaml#/Address'
+                        - $ref: '../components/starknet/schemas.yaml#/StorageKey'
+                        - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                      description: The contract address, key, and block_id
+                      minItems: 3
+                      maxItems: 3
+                      default:
+                        [
+                          '0x044e5b3f0471a26bc749ffa1d8dd8e43640e05f1b33cf05cef6adee6f5b1b4cf',
+                          '0x0000000000000000000000000000000000000000000000000000000000000001',
+                          'latest',
+                        ]
+      responses:
+        '200':
+          description: The value at the given key for the given contract. 0 if no value is found
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getStorageAt
-                      params:
-                        type: array
-                        title: Params
-                        items:
-                          - $ref: '../components/starknet/schemas.yaml#/Address'
-                          - $ref: '../components/starknet/schemas.yaml#/StorageKey'
-                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                        description: The contract address, key, and block_id
-                        minItems: 3
-                        maxItems: 3
-                        default:
-                          [
-                            '0x044e5b3f0471a26bc749ffa1d8dd8e43640e05f1b33cf05cef6adee6f5b1b4cf',
-                            '0x0000000000000000000000000000000000000000000000000000000000000001',
-                            'latest',
-                          ]
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The value at the given key for the given contract. 0 if no value is found
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/Felt'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getStorageAt'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/Felt'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getStorageAt'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getTransactionByBlockIdAndIndex.yaml
+++ b/starknet/starknet_getTransactionByBlockIdAndIndex.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getTransactionByBlockIdAndIndex
         description: Get the details of the transaction given by the identified block and index in that block. If no transaction is found, null is returned.
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getTransactionByBlockIdAndIndex.yaml
+++ b/starknet/starknet_getTransactionByBlockIdAndIndex.yaml
@@ -13,56 +13,52 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getTransactionByBlockIdAndIndex
-        summary: starknet_getTransactionByBlockIdAndIndex
-        description: Get the details of the transaction given by the identified block and index in that block. If no transaction is found, null is returned.
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getTransactionByBlockIdAndIndex
+      description: Get the details of the transaction given by the identified block and index in that block. If no transaction is found, null is returned.
+      operationId: starknet-getTransactionByBlockIdAndIndex
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getTransactionByBlockIdAndIndex
+                    params:
+                      type: array
+                      title: Params
+                      items:
+                        oneOf:
+                          - $ref: '../components/starknet/schemas.yaml#/BlockId'
+                          - type: integer
+                            minimum: 0
+                            default: 1
+                      description: The block_id and index of the requested transaction
+                      minItems: 2
+                      maxItems: 2
+      responses:
+        '200':
+          description: The details of the transaction given by the identified block and index in that block
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getTransactionByBlockIdAndIndex
-                      params:
-                        type: array
-                        title: Params
-                        items:
-                          oneOf:
-                            - $ref: '../components/starknet/schemas.yaml#/BlockId'
-                            - type: integer
-                              minimum: 0
-                              default: 1
-                        description: The block_id and index of the requested transaction
-                        minItems: 2
-                        maxItems: 2
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The details of the transaction given by the identified block and index in that block
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        transactionResult:
-                          $ref: '../components/starknet/schemas.yaml#/Txn'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getTransactionByBlockIdAndIndex'
+                      transactionResult:
+                        $ref: '../components/starknet/schemas.yaml#/Txn'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getTransactionByBlockIdAndIndex'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getTransactionByHash.yaml
+++ b/starknet/starknet_getTransactionByHash.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getTransactionByHash
         description: Get the details and status of a submitted transaction
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getTransactionByHash.yaml
+++ b/starknet/starknet_getTransactionByHash.yaml
@@ -13,56 +13,52 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getTransactionByHash
-        summary: starknet_getTransactionByHash
-        description: Get the details and status of a submitted transaction
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getTransactionByHash
+      description: Get the details and status of a submitted transaction
+      operationId: starknet-getTransactionByHash
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getTransactionByHash
+                    params:
+                      type: array
+                      title: Params
+                      default:
+                        [
+                          '0x019041241b3e0924636b94fd780eca8ed82149299a5fd2f9c90aaeabe5da8728',
+                        ]
+                      items:
+                        - $ref: '../components/starknet/schemas.yaml#/TxnHash'
+                      description: The transaction hash of the requested transaction
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The details and status of a submitted transaction
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getTransactionByHash
-                      params:
-                        type: array
-                        title: Params
-                        default:
-                          [
-                            '0x019041241b3e0924636b94fd780eca8ed82149299a5fd2f9c90aaeabe5da8728',
-                          ]
-                        items:
-                          - $ref: '../components/starknet/schemas.yaml#/TxnHash'
-                        description: The transaction hash of the requested transaction
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The details and status of a submitted transaction
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/Txn'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getTransactionByHash'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/Txn'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getTransactionByHash'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_getTransactionReceipt.yaml
+++ b/starknet/starknet_getTransactionReceipt.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_getTransactionReceipt
         description: Get the transaction receipt by the transaction hash
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_getTransactionReceipt.yaml
+++ b/starknet/starknet_getTransactionReceipt.yaml
@@ -13,56 +13,52 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-getTransactionReceipt
-        summary: starknet_getTransactionReceipt
-        description: Get the transaction receipt by the transaction hash
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_getTransactionReceipt
+      description: Get the transaction receipt by the transaction hash
+      operationId: starknet-getTransactionReceipt
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: ../components/schemas.yaml#/Method
+                      default: starknet_getTransactionReceipt
+                    params:
+                      type: array
+                      default:
+                        [
+                          '0x019041241b3e0924636b94fd780eca8ed82149299a5fd2f9c90aaeabe5da8728',
+                        ]
+                      title: Params
+                      items:
+                        - $ref: '../components/starknet/schemas.yaml#/TxnHash'
+                      description: The transaction hash of the requested transaction
+                      minItems: 1
+                      maxItems: 1
+      responses:
+        '200':
+          description: The transaction receipt by the transaction hash
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: ../components/schemas.yaml#/Method
-                        default: starknet_getTransactionReceipt
-                      params:
-                        type: array
-                        default:
-                          [
-                            '0x019041241b3e0924636b94fd780eca8ed82149299a5fd2f9c90aaeabe5da8728',
-                          ]
-                        title: Params
-                        items:
-                          - $ref: '../components/starknet/schemas.yaml#/TxnHash'
-                        description: The transaction hash of the requested transaction
-                        minItems: 1
-                        maxItems: 1
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The transaction receipt by the transaction hash
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          $ref: '../components/starknet/schemas.yaml#/TxnReceipt'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_getTransactionReceipt'
+                      result:
+                        $ref: '../components/starknet/schemas.yaml#/TxnReceipt'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_getTransactionReceipt'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_pendingTransactions.yaml
+++ b/starknet/starknet_pendingTransactions.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_pendingTransactions
         description: Returns the transactions in the transaction pool, recognized by this sequencer
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/starknet/starknet_pendingTransactions.yaml
+++ b/starknet/starknet_pendingTransactions.yaml
@@ -13,51 +13,47 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-pendingTransactions
-        summary: starknet_pendingTransactions
-        description: Returns the transactions in the transaction pool, recognized by this sequencer
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_pendingTransactions
+      description: Returns the transactions in the transaction pool, recognized by this sequencer
+      operationId: starknet-pendingTransactions
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_pendingTransactions
+                    params:
+                      type: array
+                      title: No parameters required
+                      description: This method does not require any parameters
+      responses:
+        '200':
+          description: The transactions in the transaction pool, recognized by this sequencer
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_pendingTransactions
-                      params:
+                      result:
                         type: array
-                        title: No parameters required
-                        description: This method does not require any parameters
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The transactions in the transaction pool, recognized by this sequencer
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          type: array
-                          title: Pending Transactions
-                          items:
-                            $ref: '../components/starknet/schemas.yaml#/Txn'
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_pendingTransactions'
+                        title: Pending Transactions
+                        items:
+                          $ref: '../components/starknet/schemas.yaml#/Txn'
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_pendingTransactions'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_syncing.yaml
+++ b/starknet/starknet_syncing.yaml
@@ -13,54 +13,50 @@ servers:
         default: starknet-mainnet
 paths:
   /{apiKey}:
-    $ref: '#/components/pathItems/path'
-components:
-  pathItems:
-    path:
-      post:
-        operationId: starknet-syncing
-        summary: starknet_syncing
-        description: Returns an object about the sync status, or false if the node is not synching
-        parameters:
-          - $ref: ../components/parameters.yaml#/ApiKey
-        requestBody:
-          description: Request Body
+    post:
+      summary: starknet_syncing
+      description: Returns an object about the sync status, or false if the node is not synching
+      operationId: starknet-syncing
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        description: Request Body
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '../evm_body.yaml#/common_request_fields'
+                - type: object
+                  properties:
+                    method:
+                      $ref: '../components/schemas.yaml#/Method'
+                      default: starknet_syncing
+                    params:
+                      type: array
+                      title: No parameters required
+                      description: This method does not require any parameters
+      responses:
+        '200':
+          description: The state of the synchronization, or false if the node is not synchronizing
           content:
             application/json:
               schema:
                 allOf:
-                  - $ref: '../evm_body.yaml#/common_request_fields'
+                  - $ref: '../evm_responses.yaml#/common_response_fields'
                   - type: object
                     properties:
-                      method:
-                        $ref: '../components/schemas.yaml#/Method'
-                        default: starknet_syncing
-                      params:
-                        type: array
-                        title: No parameters required
-                        description: This method does not require any parameters
-        x-readme:
-          samples-languages:
-            - curl
-            - javascript
-            - python
-        responses:
-          '200':
-            description: The state of the synchronization, or false if the node is not synchronizing
-            content:
-              application/json:
-                schema:
-                  allOf:
-                    - $ref: '../evm_responses.yaml#/common_response_fields'
-                    - type: object
-                      properties:
-                        result:
-                          oneOf:
-                            - type: boolean
-                              title: Not synchronizing
-                              description: only legal value is FALSE here
-                            - $ref: '../components/starknet/schemas.yaml#/SyncStatus'
-                              title: Sync status
-                              description: The status of the node, if it is currently synchronizing state
-                      example:
-                        $ref: '../components/starknet/examples.yaml#/starknet_syncing'
+                      result:
+                        oneOf:
+                          - type: boolean
+                            title: Not synchronizing
+                            description: only legal value is FALSE here
+                          - $ref: '../components/starknet/schemas.yaml#/SyncStatus'
+                            title: Sync status
+                            description: The status of the node, if it is currently synchronizing state
+                    example:
+                      $ref: '../components/starknet/examples.yaml#/starknet_syncing'
+      x-readme:
+        samples-languages:
+          - curl
+          - javascript
+          - python

--- a/starknet/starknet_syncing.yaml
+++ b/starknet/starknet_syncing.yaml
@@ -22,19 +22,7 @@ components:
         summary: starknet_syncing
         description: Returns an object about the sync status, or false if the node is not synching
         parameters:
-          - name: apiKey
-            in: path
-            schema:
-              type: string
-              default: docs-demo
-              description: |
-                <style>
-                  .custom-style {
-                    color: #048FF4;
-                  }
-                </style>
-                For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-            required: true
+          - $ref: ../components/parameters.yaml#/ApiKey
         requestBody:
           description: Request Body
           content:

--- a/token/alchemy_getTokenAllowance.yaml
+++ b/token/alchemy_getTokenAllowance.yaml
@@ -23,19 +23,7 @@ paths:
       description: 'Returns the amount which the spender is allowed to withdraw from the owner.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/token/alchemy_getTokenAllowance.yaml
+++ b/token/alchemy_getTokenAllowance.yaml
@@ -19,9 +19,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: alchemy_getTokenAllowance
       description: 'Returns the amount which the spender is allowed to withdraw from the owner.'
-      tags: []
+      operationId: alchemy-getTokenAllowance
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -36,4 +37,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/alchemy_getTokenAllowance
-      operationId: alchemy-getTokenAllowance

--- a/token/alchemy_getTokenAllowance.yaml
+++ b/token/alchemy_getTokenAllowance.yaml
@@ -19,7 +19,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: alchemy_getTokenAllowance
       description: 'Returns the amount which the spender is allowed to withdraw from the owner.'
       operationId: alchemy-getTokenAllowance

--- a/token/alchemy_getTokenBalances.yaml
+++ b/token/alchemy_getTokenBalances.yaml
@@ -21,7 +21,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: alchemy_getTokenBalances
       description: 'Returns ERC20 token balances for all tokens the given address has ever transacted in with. Optionally accepts a list of contracts.'
       operationId: alchemy-getTokenBalances

--- a/token/alchemy_getTokenBalances.yaml
+++ b/token/alchemy_getTokenBalances.yaml
@@ -21,9 +21,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: alchemy_getTokenBalances
       description: 'Returns ERC20 token balances for all tokens the given address has ever transacted in with. Optionally accepts a list of contracts.'
-      tags: []
+      operationId: alchemy-getTokenBalances
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -31,6 +32,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/alchemy_getTokenBalances
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/alchemy_getTokenBalances
       x-readme:
         samples-languages:
           - curl
@@ -56,11 +64,3 @@ paths:
 
               // Print token balances of USDC in Vitalik's address
               alchemy.core.getTokenBalances(vitalikAddress, [usdcContract]).then(console.log);
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/alchemy_getTokenBalances
-      operationId: alchemy-getTokenBalances

--- a/token/alchemy_getTokenBalances.yaml
+++ b/token/alchemy_getTokenBalances.yaml
@@ -25,19 +25,7 @@ paths:
       description: 'Returns ERC20 token balances for all tokens the given address has ever transacted in with. Optionally accepts a list of contracts.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/token/alchemy_getTokenMetadata.yaml
+++ b/token/alchemy_getTokenMetadata.yaml
@@ -21,7 +21,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: alchemy_getTokenMetadata
       description: 'Returns metadata (name, symbol, decimals, logo) for a given token contract address.'
       operationId: alchemy-getTokenMetadata

--- a/token/alchemy_getTokenMetadata.yaml
+++ b/token/alchemy_getTokenMetadata.yaml
@@ -21,9 +21,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: alchemy_getTokenMetadata
       description: 'Returns metadata (name, symbol, decimals, logo) for a given token contract address.'
-      tags: []
+      operationId: alchemy-getTokenMetadata
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -31,6 +32,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/alchemy_getTokenMetadata
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/alchemy_getTokenMetadata
       x-readme:
         samples-languages:
           - curl
@@ -54,11 +62,3 @@ paths:
               // Print token metadata of USDC
               const usdcContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
               alchemy.core.getTokenMetadata(usdcContract).then(console.log);
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/alchemy_getTokenMetadata
-      operationId: alchemy-getTokenMetadata

--- a/token/alchemy_getTokenMetadata.yaml
+++ b/token/alchemy_getTokenMetadata.yaml
@@ -25,19 +25,7 @@ paths:
       description: 'Returns metadata (name, symbol, decimals, logo) for a given token contract address.'
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_block.yaml
+++ b/trace/trace_block.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns traces created at given block.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_block.yaml
+++ b/trace/trace_block.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_block
       description: Returns traces created at given block.
       operationId: trace-block

--- a/trace/trace_block.yaml
+++ b/trace/trace_block.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_block
       description: Returns traces created at given block.
-      tags: []
+      operationId: trace-block
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/trace_block
-      operationId: trace-block

--- a/trace/trace_call.yaml
+++ b/trace/trace_call.yaml
@@ -17,19 +17,7 @@ paths:
       description: Executes the given call and returns a number of possible traces for it.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_call.yaml
+++ b/trace/trace_call.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_call
       description: Executes the given call and returns a number of possible traces for it.
       operationId: trace-call

--- a/trace/trace_call.yaml
+++ b/trace/trace_call.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_call
       description: Executes the given call and returns a number of possible traces for it.
-      tags: []
+      operationId: trace-call
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -23,6 +24,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/trace_call
+      responses:
+        '200':
+          description: 'Returns - Array of Block traces'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/trace_call
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -45,11 +53,3 @@ paths:
                     ["trace"]],
                   "id":1,
                   "jsonrpc":"2.0"}'
-      responses:
-        '200':
-          description: 'Returns - Array of Block traces'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/trace_call
-      operationId: trace-call

--- a/trace/trace_filter.yaml
+++ b/trace/trace_filter.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns traces matching given filter.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_filter.yaml
+++ b/trace/trace_filter.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_filter
       description: Returns traces matching given filter.
       operationId: trace-filter

--- a/trace/trace_filter.yaml
+++ b/trace/trace_filter.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_filter
       description: Returns traces matching given filter.
-      tags: []
+      operationId: trace-filter
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/trace_filter
-      operationId: trace-filter

--- a/trace/trace_get.yaml
+++ b/trace/trace_get.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_get
       description: Returns trace at given position.
       operationId: trace-get

--- a/trace/trace_get.yaml
+++ b/trace/trace_get.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns trace at given position.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_get.yaml
+++ b/trace/trace_get.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_get
       description: Returns trace at given position.
-      tags: []
+      operationId: trace-get
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -23,6 +24,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/trace_get
+      responses:
+        '200':
+          description: 'Returns - Trace object.'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/trace_get
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -37,11 +45,3 @@ paths:
               -X POST \
               -H "Content-Type: application/json" \
               -d '{"method":"trace_get","params":["0x17104ac9d3312d8c136b7f44d4b8b47852618065ebfa534bd2d3b5ef218ca1f3",["0x0"]],"id":1,"jsonrpc":"2.0"}'
-      responses:
-        '200':
-          description: 'Returns - Trace object.'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/trace_get
-      operationId: trace-get

--- a/trace/trace_rawTransaction.yaml
+++ b/trace/trace_rawTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_rawTransaction
       description: Traces a call to eth_sendRawTransaction without making the call, returning the traces.
       operationId: trace-rawTransaction

--- a/trace/trace_rawTransaction.yaml
+++ b/trace/trace_rawTransaction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_rawTransaction
       description: Traces a call to eth_sendRawTransaction without making the call, returning the traces.
-      tags: []
+      operationId: trace-rawTransaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -23,6 +24,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/trace_rawTransaction
+      responses:
+        '200':
+          description: 'Returns - Block traces'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/trace_call
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -37,11 +45,3 @@ paths:
               -X POST \
               -H "Content-Type: application/json" \
               -d '{"method":"trace_rawTransaction","params":["0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",["trace"]],"id":1,"jsonrpc":"2.0"}'
-      responses:
-        '200':
-          description: 'Returns - Block traces'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/trace_call
-      operationId: trace-rawTransaction

--- a/trace/trace_rawTransaction.yaml
+++ b/trace/trace_rawTransaction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Traces a call to eth_sendRawTransaction without making the call, returning the traces.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_replayBlockTransactions.yaml
+++ b/trace/trace_replayBlockTransactions.yaml
@@ -17,19 +17,7 @@ paths:
       description: Replays all transactions in a block returning the requested traces for each transaction.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_replayBlockTransactions.yaml
+++ b/trace/trace_replayBlockTransactions.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_replayBlockTransactions
       description: Replays all transactions in a block returning the requested traces for each transaction.
       operationId: trace-replayBlockTransactions

--- a/trace/trace_replayBlockTransactions.yaml
+++ b/trace/trace_replayBlockTransactions.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_replayBlockTransactions
       description: Replays all transactions in a block returning the requested traces for each transaction.
-      tags: []
+      operationId: trace-replayBlockTransactions
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -23,6 +24,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/trace_replayBlockTransactions
+      responses:
+        '200':
+          description: 'Returns - Array of block transactions traces.'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/trace_replayBlockTransactions
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -37,11 +45,3 @@ paths:
               -X POST \
               -H "Content-Type: application/json" \
               -d '{"method":"trace_replayBlockTransactions","params":["0x2ed119",["trace"]],"id":1,"jsonrpc":"2.0"}'
-      responses:
-        '200':
-          description: 'Returns - Array of block transactions traces.'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/trace_replayBlockTransactions
-      operationId: trace-replayBlockTransactions

--- a/trace/trace_replayTransaction.yaml
+++ b/trace/trace_replayTransaction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Traces a call to eth_sendRawTransaction without making the call, returning the traces.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_replayTransaction.yaml
+++ b/trace/trace_replayTransaction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_replayTransaction
       description: Traces a call to eth_sendRawTransaction without making the call, returning the traces.
-      tags: []
+      operationId: trace-replayTransaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -23,6 +24,13 @@ paths:
           application/json:
             schema:
               $ref: ../evm_body.yaml#/trace_replayTransaction
+      responses:
+        '200':
+          description: 'Returns - Block traces'
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/trace_call
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -37,11 +45,3 @@ paths:
               -X POST \
               -H "Content-Type: application/json" \
               -d '{"method":"trace_replayTransaction","params":["0x02d4a872e096445e80d05276ee756cefef7f3b376bcec14246469c0cd97dad8f",["trace"]],"id":1,"jsonrpc":"2.0"}'
-      responses:
-        '200':
-          description: 'Returns - Block traces'
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/trace_call
-      operationId: trace-replayTransaction

--- a/trace/trace_replayTransaction.yaml
+++ b/trace/trace_replayTransaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_replayTransaction
       description: Traces a call to eth_sendRawTransaction without making the call, returning the traces.
       operationId: trace-replayTransaction

--- a/trace/trace_transaction.yaml
+++ b/trace/trace_transaction.yaml
@@ -13,7 +13,6 @@ servers:
 paths:
   /{apiKey}:
     post:
-      tags: []
       summary: trace_transaction
       description: Returns all traces of given transaction.
       operationId: trace-transaction

--- a/trace/trace_transaction.yaml
+++ b/trace/trace_transaction.yaml
@@ -17,19 +17,7 @@ paths:
       description: Returns all traces of given transaction.
       tags: []
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/trace/trace_transaction.yaml
+++ b/trace/trace_transaction.yaml
@@ -13,9 +13,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: []
       summary: trace_transaction
       description: Returns all traces of given transaction.
-      tags: []
+      operationId: trace-transaction
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -30,4 +31,3 @@ paths:
             application/json:
               schema:
                 $ref: ../evm_responses.yaml#/trace_transaction
-      operationId: trace-transaction

--- a/transaction-receipts/alchemy_getTransactionReceipts.yaml
+++ b/transaction-receipts/alchemy_getTransactionReceipts.yaml
@@ -17,10 +17,24 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: ['Transaction Receipts Endpoints']
       summary: alchemy_getTransactionReceipts
       description: 'An enhanced API that gets all transaction receipts for a given block by number or block hash. Supported on all networks for Ethereum, Polygon, and Arbitrum.'
-      tags: ['Transaction Receipts Endpoints']
       operationId: alchemy-getTransactionReceipts
+      parameters:
+        - $ref: ../components/parameters.yaml#/ApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: ../evm_body.yaml#/alchemy_getTransactionReceipts_param
+      responses:
+        '200':
+          description: A list of transaction receipts for each transaction in this block.
+          content:
+            application/json:
+              schema:
+                $ref: ../evm_responses.yaml#/transaction_receipt
       x-readme:
         explorer-enabled: false
         samples-languages:
@@ -58,17 +72,3 @@ paths:
               };
 
               main();
-      parameters:
-        - $ref: ../components/parameters.yaml#/ApiKey
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: ../evm_body.yaml#/alchemy_getTransactionReceipts_param
-      responses:
-        '200':
-          description: A list of transaction receipts for each transaction in this block.
-          content:
-            application/json:
-              schema:
-                $ref: ../evm_responses.yaml#/transaction_receipt

--- a/transaction-receipts/alchemy_getTransactionReceipts.yaml
+++ b/transaction-receipts/alchemy_getTransactionReceipts.yaml
@@ -59,19 +59,7 @@ paths:
 
               main();
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:

--- a/transfers/alchemy_getAssetTransfers.yaml
+++ b/transfers/alchemy_getAssetTransfers.yaml
@@ -19,9 +19,10 @@ servers:
 paths:
   /{apiKey}:
     post:
+      tags: ['Transfers API Endpoints']
       summary: alchemy_getAssetTransfers
       description: 'The Transfers API allows you to easily fetch historical transactions for any address across Ethereum and supported L2s including Polygon, Arbitrum, and Optimism.'
-      tags: ['Transfers API Endpoints']
+      operationId: alchemy-getAssetTransfers 
       parameters:
         - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
@@ -29,6 +30,13 @@ paths:
           application/json:
             schema:
               $ref: evm_body.yaml#/alchemy_getAssetTransfers # path for using github actions to update, to update from CLI using rdme change to ../evm_body.yaml#/alchemy_getAssetTransfers
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: evm_responses.yaml#/alchemy_getAssetTransfers # path for using github actions to update, to update from CLI using rdme change to ../evm_responses.yaml#/alchemy_getAssetTransfers
       x-readme:
         samples-languages:
           - curl
@@ -59,11 +67,3 @@ paths:
               });
 
               console.log(res);
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: evm_responses.yaml#/alchemy_getAssetTransfers # path for using github actions to update, to update from CLI using rdme change to ../evm_responses.yaml#/alchemy_getAssetTransfers
-      operationId: alchemy-getAssetTransfers

--- a/transfers/alchemy_getAssetTransfers.yaml
+++ b/transfers/alchemy_getAssetTransfers.yaml
@@ -23,19 +23,7 @@ paths:
       description: 'The Transfers API allows you to easily fetch historical transactions for any address across Ethereum and supported L2s including Polygon, Arbitrum, and Optimism.'
       tags: ['Transfers API Endpoints']
       parameters:
-        - name: apiKey
-          in: path
-          schema:
-            type: string
-            default: docs-demo
-            description: |
-              <style>
-                .custom-style {
-                  color: #048FF4;
-                }
-              </style>
-              For higher throughput, <span class="custom-style"><a href="https://alchemy.com/?a=docs-demo" target="_blank">create your own API key</a></span>
-          required: true
+        - $ref: ../components/parameters.yaml#/ApiKey
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Problem
A lot of our code has been refactored into evm_body.yaml, evm_responses.yaml, evm_examples.yaml.

More often than not, this is not needed as the components are only used in 1 spec.
Splitting specs across multiple files makes it harder to understand what the spec is doing quickly.

Solution
Keep only code shared across multiple specs in evm_body.yaml, evm_responses.yaml, evm_examples.yaml.