### PR TITLE
Fix network support

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -26,7 +26,7 @@ paths:
   '/v2/{apiKey}/getNFTs':
     get:
       summary: getNFTs
-      description: Gets all NFTs currently owned by a given address. TEST
+      description: Gets all NFTs currently owned by a given address.
       tags: ['Ownership & Token Gating']
       parameters:
         - $ref: '#/components/schemas/owner'

--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: 🎨 NFT API
   version: '1.0'
-servers:
+servers: # servers are also specified at the method level, if there ins't a specification then the server is supported on all the networks below
   - url: https://{network}.g.alchemy.com/nft
     variables:
       network:
@@ -26,7 +26,7 @@ paths:
   '/v2/{apiKey}/getNFTs':
     get:
       summary: getNFTs
-      description: Gets all NFTs currently owned by a given address.
+      description: Gets all NFTs currently owned by a given address. TEST
       tags: ['Ownership & Token Gating']
       parameters:
         - $ref: '#/components/schemas/owner'
@@ -461,6 +461,14 @@ paths:
       summary: getSpamContracts
       description: Returns a list of all spam contracts marked by Alchemy.
       tags: ['Spam Detection']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
       x-readme:
@@ -506,6 +514,14 @@ paths:
       summary: isSpamContract
       description: Returns whether a contract is marked as spam or not by Alchemy.
       tags: ['Spam Detection']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -604,6 +620,13 @@ paths:
       summary: reingestContract
       description: Triggers metadata refresh for an entire NFT collection and refreshes stale metadata after a collection reveal/collection changes.
       tags: ['NFT Metadata Access']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -665,6 +688,13 @@ paths:
       summary: getFloorPrice
       description: Returns the floor prices of a NFT collection by marketplace.
       tags: ['Sales & Marketplace Data']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -729,6 +759,14 @@ paths:
       summary: computeRarity
       description: Computes the rarity of each attribute of an NFT.
       tags: ['Rarity Data']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -770,6 +808,13 @@ paths:
       summary: searchContractMetadata
       description: Search for a keyword across metadata of all ERC-721 and ERC-1155 smart contracts
       tags: ['NFT Metadata Access']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/query'
@@ -799,6 +844,14 @@ paths:
       summary: summarizeNFTAttributes
       description: Generate a summary of attribute prevalence for an NFT collection.
       tags: ['Rarity Data']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -858,6 +911,15 @@ paths:
       summary: getNFTSales
       description: Gets NFT sales that have happened through on-chain marketplaces
       tags: ['Sales & Marketplace Data']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+                - opt-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/fromBlock'
@@ -1376,8 +1438,24 @@ paths:
       summary: getSpamContracts
       description: Returns a list of all spam contracts marked by Alchemy.
       tags: ['NFT API V3 Methods (BETA)']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       x-readme:
         samples-languages:
           - javascript
@@ -1404,6 +1482,14 @@ paths:
       summary: isSpamContract
       description: Returns whether a contract is marked as spam or not by Alchemy.
       tags: ['NFT API V3 Methods (BETA)']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -1462,6 +1548,13 @@ paths:
       summary: getFloorPrice
       description: Returns the floor prices of a NFT collection by marketplace.
       tags: ['NFT API V3 Methods (BETA)']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -1507,6 +1600,14 @@ paths:
       summary: computeRarity
       description: Computes the rarity of each attribute of an NFT.
       tags: ['NFT API V3 Methods (BETA)']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -1574,6 +1675,14 @@ paths:
       summary: summarizeNFTAttributes
       description: Generate a summary of attribute prevalence for an NFT collection.
       tags: ['NFT API V3 Methods (BETA)']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/contractAddress'
@@ -1638,6 +1747,15 @@ paths:
       summary: getNFTSales
       description: Gets NFT sales that have happened through on-chain marketplaces
       tags: ['NFT API V3 Methods (BETA)']
+      servers:
+        - url: https://{network}.g.alchemy.com/nft
+          variables:
+            network:
+              enum:
+                - eth-mainnet
+                - polygon-mainnet
+                - opt-mainnet
+              default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
         - $ref: '#/components/schemas/fromBlock'


### PR DESCRIPTION
Readme does not currently support method level `servers` object.

We had it nonetheless to clearly document in our specs what methods are available on which networks.
If no `servers` object defined at the method level, fallback to the parent `servers` object.