### PR TITLE
fix base goerli testnet url

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -17,7 +17,7 @@ servers:
           - opt-mainnet
           - opt-goerli
           - base-mainnet
-          - base-testnet
+          - base-goerli
         default: eth-mainnet
 paths:
   ##

--- a/token/alchemy_getTokenBalances.yaml
+++ b/token/alchemy_getTokenBalances.yaml
@@ -16,7 +16,7 @@ servers:
           - opt-mainnet
           - opt-goerli
           - base-mainnet
-          - base-testnet
+          - base-goerli
         default: eth-mainnet
 paths:
   /{apiKey}:

--- a/transfers/alchemy_getAssetTransfers.yaml
+++ b/transfers/alchemy_getAssetTransfers.yaml
@@ -15,6 +15,8 @@ servers:
           - arb-goerli
           - opt-mainnet
           - opt-goerli
+          - base-mainnet
+          - base-goerli
         default: eth-mainnet
 paths:
   /{apiKey}:


### PR DESCRIPTION
Accidentally added “base-testnet” url instead of “base-goerli” for the network name. This fixes that!