### PR TITLE
fixed the enum issue and duplicate server

### DIFF
--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1157,7 +1157,7 @@ alchemy_getAssetTransfers:
                     - erc721
                     - erc1155
                     - specialnft
-                default: ['external']
+                  default: external
               order:
                 type: string
                 description: |

--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -1453,14 +1453,6 @@ paths:
               default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
-      servers:
-        - url: https://{network}.g.alchemy.com/nft
-          variables:
-            network:
-              enum:
-                - eth-mainnet
-                - polygon-mainnet
-              default: eth-mainnet
       x-readme:
         samples-languages:
           - javascript
@@ -2131,7 +2123,7 @@ components:
           enum:
             - SPAM
             - AIRDROPS
-          default: [SPAM]
+          default: SPAM
       in: query
     address:
       name: address
@@ -2155,7 +2147,7 @@ components:
           enum:
             - SPAM
             - AIRDROPS
-          default: [SPAM]
+          default: SPAM
       in: query
     spamConfidenceLevel:
       name: spamConfidenceLevel


### PR DESCRIPTION
we were nesting the default array inside of the `items` definition which is not correct. Also removed a duplicate server issue