### PR TITLE
add revertReason to tx simulation endpoints

### DIFF
--- a/transact/alchemy_simulateAssetChanges.yaml
+++ b/transact/alchemy_simulateAssetChanges.yaml
@@ -120,7 +120,7 @@ components:
             message:
               type: string
             revertReason:
-              $ref: '#/components/schemas/RevertMsg'
+              $ref: '#/components/schemas/RevertMessage'
 
     AssetChange:
       type: object
@@ -177,8 +177,9 @@ components:
         tokenId:
           type: [number, 'null']
 
-    RevertMsg:
-      type: [string, 'null']
+    RevertMessage:
+      type: string
+      nullable: true
       description: >
         The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's

--- a/transact/alchemy_simulateAssetChanges.yaml
+++ b/transact/alchemy_simulateAssetChanges.yaml
@@ -120,7 +120,7 @@ components:
             message:
               type: string
             revertReason:
-              $ref: '#/components/schemas/revertMsg'
+              $ref: '#/components/schemas/RevertMsg'
 
     AssetChange:
       type: object
@@ -177,7 +177,7 @@ components:
         tokenId:
           type: [number, 'null']
 
-    revertMsg:
+    RevertMsg:
       type: [string, 'null']
       description: >
         The reason why a transaction would revert. This provides you

--- a/transact/alchemy_simulateAssetChanges.yaml
+++ b/transact/alchemy_simulateAssetChanges.yaml
@@ -180,7 +180,7 @@ components:
     revertMsg:
       type: [string, 'null']
       description: >
-        The reason why a transaction would revert. This provides developers
+        The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's
         potential failure before actually executing it. For example, a revert
         reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateAssetChanges.yaml
+++ b/transact/alchemy_simulateAssetChanges.yaml
@@ -95,6 +95,7 @@ paths:
                               'amount': '1',
                             },
                           ],
+                        'gasUsed': '0x5208',
                         'error': null,
                       },
                   }
@@ -111,8 +112,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AssetChange'
-        error:
+        gasUsed:
           type: [string, 'null']
+        error:
+          type: [object, 'null']
+          properties:
+            message:
+              type: string
+            revertReason:
+              $ref: '#/components/schemas/revertMsg'
 
     AssetChange:
       type: object
@@ -168,3 +176,11 @@ components:
           type: [string, 'null']
         tokenId:
           type: [number, 'null']
+
+    revertMsg:
+      type: [string, 'null']
+      description: >
+        The reason why a transaction would revert. This provides developers
+        with the ability to understand the cause behind a transaction's
+        potential failure before actually executing it. For example, a revert
+        reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateAssetChangesBundle.yaml
+++ b/transact/alchemy_simulateAssetChangesBundle.yaml
@@ -112,7 +112,7 @@ components:
             message:
               type: string
             revertReason:
-              $ref: '#/components/schemas/RevertMsg'
+              $ref: '#/components/schemas/RevertMessage'
               
 
     AssetChange:
@@ -175,8 +175,9 @@ components:
             - number
             - 'null'
     
-    RevertMsg:
-      type: [string, 'null']
+    RevertMessage:
+      type: string
+      nullable: true
       description: >
         The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's

--- a/transact/alchemy_simulateAssetChangesBundle.yaml
+++ b/transact/alchemy_simulateAssetChangesBundle.yaml
@@ -112,7 +112,7 @@ components:
             message:
               type: string
             revertReason:
-              $ref: '#/components/schemas/revertMsg'
+              $ref: '#/components/schemas/RevertMsg'
               
 
     AssetChange:
@@ -175,7 +175,7 @@ components:
             - number
             - 'null'
     
-    revertMsg:
+    RevertMsg:
       type: [string, 'null']
       description: >
         The reason why a transaction would revert. This provides you

--- a/transact/alchemy_simulateAssetChangesBundle.yaml
+++ b/transact/alchemy_simulateAssetChangesBundle.yaml
@@ -107,9 +107,14 @@ components:
           items:
             $ref: '#/components/schemas/AssetChange'
         error:
-          type:
-            - string
-            - 'null'
+          type: [object, 'null']
+          properties:
+            message:
+              type: string
+            revertReason:
+              $ref: '#/components/schemas/revertMsg'
+              
+
     AssetChange:
       type: object
       required:
@@ -169,3 +174,11 @@ components:
           type:
             - number
             - 'null'
+    
+    revertMsg:
+      type: [string, 'null']
+      description: >
+        The reason why a transaction would revert. This provides developers
+        with the ability to understand the cause behind a transaction's
+        potential failure before actually executing it. For example, a revert
+        reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateAssetChangesBundle.yaml
+++ b/transact/alchemy_simulateAssetChangesBundle.yaml
@@ -178,7 +178,7 @@ components:
     revertMsg:
       type: [string, 'null']
       description: >
-        The reason why a transaction would revert. This provides developers
+        The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's
         potential failure before actually executing it. For example, a revert
         reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateExecution.yaml
+++ b/transact/alchemy_simulateExecution.yaml
@@ -506,7 +506,7 @@ components:
         error:
           type: string
         revertReason:
-          $ref: '#/components/schemas/RevertMsg'
+          $ref: '#/components/schemas/RevertMessage'
             
     Call:
       type: object
@@ -650,8 +650,9 @@ components:
         indexed:
           type: boolean
 
-    RevertMsg:
-      type: [string, 'null']
+    RevertMessage:
+      type: string
+      nullable: true
       description: >
         The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's

--- a/transact/alchemy_simulateExecution.yaml
+++ b/transact/alchemy_simulateExecution.yaml
@@ -653,7 +653,7 @@ components:
     revertMsg:
       type: [string, 'null']
       description: >
-        The reason why a transaction would revert. This provides developers
+        The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's
         potential failure before actually executing it. For example, a revert
         reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateExecution.yaml
+++ b/transact/alchemy_simulateExecution.yaml
@@ -504,7 +504,12 @@ components:
           items:
             $ref: '#/components/schemas/Log'
         error:
-          type: [string, 'null']
+          type: [object, 'null']
+          properties:
+            message:
+              type: string
+            revertReason:
+              $ref: '#/components/schemas/revertMsg'
 
     Call:
       type: object
@@ -647,3 +652,11 @@ components:
             - type: string
         indexed:
           type: boolean
+
+    revertMsg:
+      type: [string, 'null']
+      description: >
+        The reason why a transaction would revert. This provides developers
+        with the ability to understand the cause behind a transaction's
+        potential failure before actually executing it. For example, a revert
+        reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateExecution.yaml
+++ b/transact/alchemy_simulateExecution.yaml
@@ -504,13 +504,10 @@ components:
           items:
             $ref: '#/components/schemas/Log'
         error:
-          type: [object, 'null']
-          properties:
-            message:
-              type: string
-            revertReason:
-              $ref: '#/components/schemas/revertMsg'
-
+          type: string
+        revertReason:
+          $ref: '#/components/schemas/revertMsg'
+            
     Call:
       type: object
       required:

--- a/transact/alchemy_simulateExecution.yaml
+++ b/transact/alchemy_simulateExecution.yaml
@@ -506,7 +506,7 @@ components:
         error:
           type: string
         revertReason:
-          $ref: '#/components/schemas/revertMsg'
+          $ref: '#/components/schemas/RevertMsg'
             
     Call:
       type: object
@@ -650,7 +650,7 @@ components:
         indexed:
           type: boolean
 
-    revertMsg:
+    RevertMsg:
       type: [string, 'null']
       description: >
         The reason why a transaction would revert. This provides you

--- a/transact/alchemy_simulateExecutionBundle.yaml
+++ b/transact/alchemy_simulateExecutionBundle.yaml
@@ -458,7 +458,7 @@ components:
         error:
           type: string
         revertReason:
-          $ref: '#/components/schemas/RevertMsg'
+          $ref: '#/components/schemas/RevertMessage'
 
     Call:
       type: object
@@ -593,8 +593,9 @@ components:
         indexed:
           type: boolean
 
-    RevertMsg:
-      type: [string, 'null']
+    RevertMessage:
+      type: string
+      nullable: true
       description: >
         The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's

--- a/transact/alchemy_simulateExecutionBundle.yaml
+++ b/transact/alchemy_simulateExecutionBundle.yaml
@@ -456,9 +456,13 @@ components:
           items:
             $ref: '#/components/schemas/Log'
         error:
-          type:
-            - string
-            - 'null'
+          type: [object, 'null']
+          properties:
+            message:
+              type: string
+            revertReason:
+              $ref: '#/components/schemas/revertMsg'
+
     Call:
       type: object
       required:
@@ -591,3 +595,11 @@ components:
             - type: string
         indexed:
           type: boolean
+
+    revertMsg:
+      type: [string, 'null']
+      description: >
+        The reason why a transaction would revert. This provides developers
+        with the ability to understand the cause behind a transaction's
+        potential failure before actually executing it. For example, a revert
+        reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateExecutionBundle.yaml
+++ b/transact/alchemy_simulateExecutionBundle.yaml
@@ -596,7 +596,7 @@ components:
     revertMsg:
       type: [string, 'null']
       description: >
-        The reason why a transaction would revert. This provides developers
+        The reason why a transaction would revert. This provides you
         with the ability to understand the cause behind a transaction's
         potential failure before actually executing it. For example, a revert
         reason could be "ERC20: transfer amount exceeds allowance".

--- a/transact/alchemy_simulateExecutionBundle.yaml
+++ b/transact/alchemy_simulateExecutionBundle.yaml
@@ -456,12 +456,9 @@ components:
           items:
             $ref: '#/components/schemas/Log'
         error:
-          type: [object, 'null']
-          properties:
-            message:
-              type: string
-            revertReason:
-              $ref: '#/components/schemas/revertMsg'
+          type: string
+        revertReason:
+          $ref: '#/components/schemas/revertMsg'
 
     Call:
       type: object

--- a/transact/alchemy_simulateExecutionBundle.yaml
+++ b/transact/alchemy_simulateExecutionBundle.yaml
@@ -458,7 +458,7 @@ components:
         error:
           type: string
         revertReason:
-          $ref: '#/components/schemas/revertMsg'
+          $ref: '#/components/schemas/RevertMsg'
 
     Call:
       type: object
@@ -593,7 +593,7 @@ components:
         indexed:
           type: boolean
 
-    revertMsg:
+    RevertMsg:
       type: [string, 'null']
       description: >
         The reason why a transaction would revert. This provides you


### PR DESCRIPTION
- add the new `revertReason` option in response of all tx simulation endpoints
- add the `gasUsed` missing param in `alchemy_simulateAssetChanges`