### PR TITLE
fix gh action failing for nfts.yaml

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -1453,14 +1453,6 @@ paths:
               default: eth-mainnet
       parameters:
         - $ref: '#/components/schemas/apiKey'
-      servers:
-        - url: https://{network}.g.alchemy.com/nft
-          variables:
-            network:
-              enum:
-                - eth-mainnet
-                - polygon-mainnet
-              default: eth-mainnet
       x-readme:
         samples-languages:
           - javascript


### PR DESCRIPTION
Had duplicated `server` component within one `get` method that resulted in the failing of GH action to update NFT API

![image](https://github.com/alchemyplatform/docs-openapi-specs/assets/83442423/66c74ed1-fde5-499b-8b7d-350e3d81c53e)
