### PR TITLE
fix path for gh actions in NFT API

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -22,7 +22,7 @@ servers: # servers are also specified at the method level, if there ins't a spec
 x-sandbox:
   category:
     type:
-      $ref: '../components/sandbox.yaml#/Category'
+      $ref: 'components/sandbox.yaml#/Category' # change the path to "../components/sandbox.yaml#/Category" if updating the spec from CLI
     value: nft
 paths:
   ##


### PR DESCRIPTION
fix the path that was wrong according to GH actions making it fail.