### PR TITLE
add starknet sepolia support to starknet apis and fix base testnet issue with webhooks

### DIFF
--- a/notify/notify.yaml
+++ b/notify/notify.yaml
@@ -1019,7 +1019,7 @@ components:
         - OPT_MAINNET
         - OPT_KOVAN
         - BASE_MAINNET
-        - BASE_TESTNET
+        - BASE_GOERLI
 
       default: ETH_MAINNET
     webhook_type:

--- a/starknet/starknet_addDeclareTransaction.yaml
+++ b/starknet/starknet_addDeclareTransaction.yaml
@@ -11,7 +11,6 @@ servers:
           - starknet-mainnet
           - starknet-goerli
           - starknet-sepolia
-          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:

--- a/starknet/starknet_addDeclareTransaction.yaml
+++ b/starknet/starknet_addDeclareTransaction.yaml
@@ -10,6 +10,8 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +19,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_addDeployAccountTransaction.yaml
+++ b/starknet/starknet_addDeployAccountTransaction.yaml
@@ -11,7 +11,6 @@ servers:
           - starknet-mainnet
           - starknet-goerli
           - starknet-sepolia
-          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:

--- a/starknet/starknet_addDeployAccountTransaction.yaml
+++ b/starknet/starknet_addDeployAccountTransaction.yaml
@@ -10,6 +10,8 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +19,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_addInvokeTransaction.yaml
+++ b/starknet/starknet_addInvokeTransaction.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_blockHashAndNumber.yaml
+++ b/starknet/starknet_blockHashAndNumber.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_blockNumber.yaml
+++ b/starknet/starknet_blockNumber.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_call.yaml
+++ b/starknet/starknet_call.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_chainId.yaml
+++ b/starknet/starknet_chainId.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_estimateFee.yaml
+++ b/starknet/starknet_estimateFee.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_estimateMessageFee.yaml
+++ b/starknet/starknet_estimateMessageFee.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getBlockTransactionCount.yaml
+++ b/starknet/starknet_getBlockTransactionCount.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getBlockWithTxHashes.yaml
+++ b/starknet/starknet_getBlockWithTxHashes.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getBlockWithTxs.yaml
+++ b/starknet/starknet_getBlockWithTxs.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getClass.yaml
+++ b/starknet/starknet_getClass.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getClassAt.yaml
+++ b/starknet/starknet_getClassAt.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getClassHashAt.yaml
+++ b/starknet/starknet_getClassHashAt.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getEvents.yaml
+++ b/starknet/starknet_getEvents.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getNonce.yaml
+++ b/starknet/starknet_getNonce.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getStateUpdate.yaml
+++ b/starknet/starknet_getStateUpdate.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getStorageAt.yaml
+++ b/starknet/starknet_getStorageAt.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getTransactionByBlockIdAndIndex.yaml
+++ b/starknet/starknet_getTransactionByBlockIdAndIndex.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getTransactionByHash.yaml
+++ b/starknet/starknet_getTransactionByHash.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_getTransactionReceipt.yaml
+++ b/starknet/starknet_getTransactionReceipt.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_pendingTransactions.yaml
+++ b/starknet/starknet_pendingTransactions.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:

--- a/starknet/starknet_syncing.yaml
+++ b/starknet/starknet_syncing.yaml
@@ -10,6 +10,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
   - url: 'https://{network}.g.alchemy.com/starknet/version/rpc/{version}/'
     variables:
@@ -17,6 +18,7 @@ servers:
         enum:
           - starknet-mainnet
           - starknet-goerli
+          - starknet-sepolia
         default: starknet-mainnet
       version:
         enum:


### PR DESCRIPTION
- adds starknet-sepolia support to all Starknet APIs
- changes `BASE_TESTNET` to `BASE_GOERLI` for webhooks as that's the correct option