### PR TITLE
fix: Update regex for Hex, gasPrice, value

### DIFF
--- a/components/schemas.yaml
+++ b/components/schemas.yaml
@@ -1,6 +1,6 @@
 Hex:
   type: string
-  pattern: '^0[xX][0-9a-fA-F]+$'
+  pattern: '^0[xX][0-9a-fA-F]*$'
 
 # TODO: this does not currently allow for ENS addresses (e.g. vitalik.eth)
 Address:

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1611,19 +1611,19 @@ transaction_object:
     gas:
       type: string
       description: Integer of the gas provided for the transaction execution.
-      pattern: '^0[xX]([1-9a-fA-F]+[0-9a-fA-F]*|0)$'
-      default: '0x00'
+      pattern: '^0[xX]([1-9a-fA-F][0-9a-fA-F]*|0)$'
+      default: '0x0'
     gasPrice:
       type: string
       description: |
         Integer of the gasPrice used for each paid gas.
         <br/><strong>NOTE:</strong> most of our users <b>(95%+)</b> never set the gasPrice on eth_call.
-      pattern: '^0[xX]([1-9a-fA-F]+[0-9a-fA-F]*|0)$'
+      pattern: '^0[xX]([1-9a-fA-F][0-9a-fA-F]*|0)$'
       default: '0x9184e72a000'
     value:
       type: string
       description: Integer of the value sent with this transaction
-      pattern: '^0[xX]([1-9a-fA-F]+[0-9a-fA-F]*|0)$'
+      pattern: '^0[xX]([1-9a-fA-F][0-9a-fA-F]*|0)$'
       default: '0x0'
     data:
       type: string

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1618,13 +1618,13 @@ transaction_object:
       description: |
         Integer of the gasPrice used for each paid gas.
         <br/><strong>NOTE:</strong> most of our users <b>(95%+)</b> never set the gasPrice on eth_call.
-      pattern: '^0[xX][0-9a-fA-F]+$'
-      default: '0x09184e72a000'
+      pattern: '^0[xX]([1-9a-fA-F]+[0-9a-fA-F]*|0)$'
+      default: '0x9184e72a000'
     value:
       type: string
       description: Integer of the value sent with this transaction
-      pattern: '^0[xX][0-9a-fA-F]+$'
-      default: '0x00'
+      pattern: '^0[xX]([1-9a-fA-F]+[0-9a-fA-F]*|0)$'
+      default: '0x0'
     data:
       type: string
       description: Hash of the method signature and encoded parameters

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1602,12 +1602,12 @@ transaction_object:
     from:
       type: string
       description: 20 Bytes - The address the transaction is sent from.
-      pattern: '^0[xX][0-9a-fA-F]+$'
+      pattern: '^0[xX][0-9a-fA-F]{40}$'
     to:
       type: string
       description: 20 Bytes - The address the transaction is directed to
       default: '0xd46e8dd67c5d32be8058bb8eb970870f07244567'
-      pattern: '^0[xX][0-9a-fA-F]+$'
+      pattern: '^0[xX][0-9a-fA-F]{40}$'
     gas:
       type: string
       description: Integer of the gas provided for the transaction execution.

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -1611,7 +1611,7 @@ transaction_object:
     gas:
       type: string
       description: Integer of the gas provided for the transaction execution.
-      pattern: '^0[xX][0-9a-fA-F]+$'
+      pattern: '^0[xX]([1-9a-fA-F]+[0-9a-fA-F]*|0)$'
       default: '0x00'
     gasPrice:
       type: string


### PR DESCRIPTION
Updating some regex patterns.

### Hex
The current pattern doesn't allow "empty" values like `0x` even though that's the default value.

### `gas`, `gasPrice`, and `value`
We shouldn't allow leading zeroes. See [specification](https://ethereum.github.io/execution-apis/api-documentation/).

### `to` and `from`
Should be 40-digit addresses.