### PR TITLE
Add 0.7 user operations to account abstraction specs

### DIFF
--- a/components/schemas.yaml
+++ b/components/schemas.yaml
@@ -97,7 +97,13 @@ Method:
 # ================= Account Abstraction =================
 
 UserOperationPartial:
-  title: User Operation ( missing signature, paymasterData, and gas fields )
+  title: User Operation, either v0.6 or v0.7 ( missing signature, paymasterData, and gas fields )
+  oneOf:
+    - $ref: '#/UserOperationPartialV0_6'
+    - $ref: '#/UserOperationPartialV0_7'
+
+UserOperationPartialV0_6:
+  title: User Operation v0.6 ( missing signature, paymasterData, and gas fields )
   type: object
   properties:
     sender:
@@ -118,11 +124,43 @@ UserOperationPartial:
         Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the user operation.
       default: '0xb61d27f600000000000000000000000043f6bfbe9dad44cf0a60570c30c307d949be4cd40000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000645c833bfd000000000000000000000000613c64104b98b048b93289ed20aefd80912b3cde0000000000000000000000000000000000000000000000000de123e8a84f9901000000000000000000000000c9371ea30dea5ac745b71e191ba8cde2c4e66df500000000000000000000000000000000000000000000000000000000'
 
+UserOperationPartialV0_7:
+  title: User Operation v0.7 ( missing signature, paymasterData, and gas fields )
+  type: object
+  properties:
+    sender:
+      $ref: '#/Hex'
+      description: The account making the operation
+      default: '0xceb161d3e0B6d01bc0e87ECC27fF9f2E2eCDCD81'
+    nonce:
+      $ref: '#/Hex'
+      description: Anti-replay parameter; also used as the salt for first-time account creation
+      default: '0x3'
+    factory:
+      $ref: '#/Hex'
+      description: The account factory address (needed if and only if the account is not yet on-chain and needs to be created)
+      default: '0x5061010c6114f7565b5061010c6114d6565B5061'
+    factoryData:
+      $ref: '#/Hex'
+      description: Data for the account factory (only if the account factory exists)
+      default: '0x'
+    callData:
+      $ref: '#/Hex'
+      description: |
+        Encoded data for executing the primary function call or operation within the user's transaction, such as calling a smart contract function or transferring tokens. This data is passed to the sender's address during the execution of the user operation.
+      default: '0xb61d27f600000000000000000000000043f6bfbe9dad44cf0a60570c30c307d949be4cd40000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000645c833bfd000000000000000000000000613c64104b98b048b93289ed20aefd80912b3cde0000000000000000000000000000000000000000000000000de123e8a84f9901000000000000000000000000c9371ea30dea5ac745b71e191ba8cde2c4e66df500000000000000000000000000000000000000000000000000000000'
+
 UserOperationPartialWithGasFields:
-  title: User Operation ( missing signature and paymasterData )
+  title: User Operation, either v0.6 or v0.7 ( missing signature and paymasterData )
+  oneOf:
+    - $ref: '#/UserOperationPartialWithGasFieldsV0_6'
+    - $ref: '#/UserOperationPartialWithGasFieldsV0_7'
+
+UserOperationPartialWithGasFieldsV0_6:
+  title: User Operation v0.6 ( missing signature and paymasterData )
   type: object
   allOf:
-    - $ref: '#/UserOperationPartial'
+    - $ref: '#/UserOperationPartialV0_6'
     - type: object
       properties:
         callGasLimit:
@@ -146,17 +184,83 @@ UserOperationPartialWithGasFields:
           description: Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)
           default: '0x13AB6680'
 
-UserOperation:
-  title: User Operation
+UserOperationPartialWithGasFieldsV0_7:
+  title: User Operation v0.7 ( missing signature and paymasterData )
   type: object
   allOf:
-    - $ref: '#/UserOperationPartialWithGasFields'
+    - $ref: '#/UserOperationPartialV0_7'
+    - type: object
+      properties:
+        callGasLimit:
+          $ref: '#/Hex'
+          description: The amount of gas to allocate the main execution call
+          default: '0x7A1200'
+        verificationGasLimit:
+          $ref: '#/Hex'
+          description: The amount of gas to allocate for the verification step
+          default: '0x927C0'
+        preVerificationGas:
+          $ref: '#/Hex'
+          description: The amount of gas to pay for to compensate the bundler for pre-verification execution and calldata
+          default: '0x15F90'
+        maxFeePerGas:
+          $ref: '#/Hex'
+          description: The maximum fee per gas to pay for the execution of this operation (similar to EIP-1559 max_fee_per_gas)
+          default: '0x656703D00'
+        maxPriorityFeePerGas:
+          $ref: '#/Hex'
+          description: Maximum priority fee per gas (similar to EIP-1559 max_priority_fee_per_gas)
+          default: '0x13AB6680'
+        paymasterVerificationGasLimit:
+          $ref: '#/Hex'
+          description: The amount of gas to allocate for the paymaster validation code (only if a paymaster exists)
+          default: '0x927C0'
+        paymasterPostOpGasLimit:
+          $ref: '#/Hex'
+          description: The amount of gas to allocate for the paymaster post-op code (only if a paymaster exists)
+          default: '0x927C0'
+
+UserOperation:
+  title: User Operation, either v0.6 or v0.7
+  oneOf:
+    - $ref: '#/UserOperationV0_6'
+    - $ref: '#/UserOperationV0_7'
+
+UserOperationV0_6:
+  title: User Operation v0.7
+  type: object
+  allOf:
+    - $ref: '#/UserOperationPartialWithGasFieldsV0_6'
     - type: object
       properties:
         signature:
           $ref: '#/Hex'
           description: Data passed into the account along with the nonce during the verification step
           default: '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c'
+        paymasterAndData:
+          $ref: '#/Hex'
+          description: Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)
+          default: '0x9db7f05b0eb93eb242b5913596dcfaada756af5c'
+
+UserOperationV0_7:
+  title: User Operation v0.7
+  type: object
+  allOf:
+    - $ref: '#/UserOperationPartialWithGasFieldsV0_7'
+    - type: object
+      properties:
+        signature:
+          $ref: '#/Hex'
+          description: Data passed into the account along with the nonce during the verification step
+          default: '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c'
+        paymaster:
+          $ref: '#/Hex'
+          description: Address of the paymaster contract (or empty, if the account pays for itself)
+          default: '0x9db7f05b0eb93eb242b5913596dcfaada756af5c'
+        paymasterData:
+          $ref: '#/Hex'
+          description: Data for the paymaster (only if the paymaster exists)
+          default: '0x'
         paymasterAndData:
           $ref: '#/Hex'
           description: Address of paymaster sponsoring the transaction, followed by extra data to send to the paymaster (empty for self-sponsored transaction)

--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -2293,8 +2293,8 @@ eth_sendUserOperation:
         params:
           type: array
           description: |
-            1. Object - The `UserOperation` object
-            2. String - The `entrypoint` address the request should be sent through. This MUST be one of the entry points returned by the supportedEntryPoints rpc call.
+            1. Object - The `UserOperation` object. This can be either a v0.6 or v0.7 user operation, but MUST match the version of the entry point at the address of the second parameter.
+            2. String - The `entrypoint` address the request should be sent through. This MUST be one of the entry points returned by the supportedEntryPoints rpc call and match the version of the user operation in the first parameter.
 
             **NOTE:** You'll see two of each parameters below, this has to do with OpenAPI formatting. To test the request, please fill in the **User Operation** field in the first box and the **Entrypoint Address** in the second box.
           minItems: 2
@@ -2318,8 +2318,8 @@ eth_estimateUserOperationGas:
         params:
           type: array
           description: |
-            1. Object - The `UserOperation` object (gas limits and prices are optional)
-            2. String - The `entrypoint` address the request should be sent through. This MUST be one of the entry points returned by the supportedEntryPoints rpc call.
+            1. Object - The `UserOperation` object (gas limits and prices are optional). This can be either a v0.6 or v0.7 user operation, but MUST match the version of the entry point at the address of the second parameter.
+            2. String - The `entrypoint` address the request should be sent through. This MUST be one of the entry points returned by the supportedEntryPoints rpc call and match the version of the user operation in the first parameter.
 
             **NOTE:** You'll see two of each parameters below, this has to do with OpenAPI formatting. To test the request, please fill in the **User Operation** field in the first box and the **Entrypoint Address** in the second box.
           minItems: 2
@@ -2399,9 +2399,11 @@ alchemy_requestPaymasterAndData:
                 default: '0x1234567890123456789012345678901234567890123456789012345678901234'
               entryPoint:
                 $ref: ./components/schemas.yaml#/EntryPoint
+                description: The `entrypoint` address the request should be sent through. This MUST be one of the entry points returned by the supportedEntryPoints rpc call and match the version of the user operation in the `userOperation` field.
+                default: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
               userOperation:
                 $ref: ./components/schemas.yaml#/UserOperationPartialWithGasFields
-                description: Partial UserOperation object, missing paymasterAndData and signature fields
+                description: Partial UserOperation object, missing paymasterAndData and signature fields. This can be either a v0.6 or v0.7 user operation, but MUST match the version of the entry point at the address in the `entryPoint` field.
 
 alchemy_requestGasAndPaymasterAndData:
   allOf:
@@ -2425,6 +2427,7 @@ alchemy_requestGasAndPaymasterAndData:
                 default: '69d524a7-e932-4214-8673-dcdcba31bb42'
               entryPoint:
                 $ref: ./components/schemas.yaml#/EntryPoint
+                description: The `entrypoint` address the request should be sent through. This MUST be one of the entry points returned by the supportedEntryPoints rpc call and match the version of the user operation in the `userOperation` field.
                 default: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789'
               dummySignature:
                 type: string
@@ -2432,7 +2435,7 @@ alchemy_requestGasAndPaymasterAndData:
                 default: '0xe8fe34b166b64d118dccf44c7198648127bf8a76a48a042862321af6058026d276ca6abb4ed4b60ea265d1e57e33840d7466de75e13f072bbd3b7e64387eebfe1b'
               userOperation:
                 $ref: ./components/schemas.yaml#/UserOperationPartial
-                description: Partial UserOperation object, missing gas parameters, paymasterAndData and signature fields.
+                description: Partial UserOperation object, missing gas parameters, paymasterAndData and signature fields. This can be either a v0.6 or v0.7 user operation, but MUST match the version of the entry point at the address in the `entryPoint` field.
               overrides:
                 type: object
                 description: Optional fields to override default gas and fee behavior - this will apply either multiplier overrides relative to our default estimates or absolute overrides

--- a/evm_responses.yaml
+++ b/evm_responses.yaml
@@ -1487,6 +1487,9 @@ eth_estimateUserOperationGas:
             callGasLimit:
               type: integer
               description: Value used by inner account execution
+            paymasterVerificationGasLimit:
+              type: integer
+              description: Value used by the paymaster during verification. Only present if the request used a v0.7 user operation that contained a paymaster.
       example:
         $ref: ./evm_examples.yaml#/eth_estimateUserOperationGas
 


### PR DESCRIPTION
Turns the old `UserOperation` into `UserOperationV0_6`, adds a new type `UserOperationV0_7`, and sets the new `UserOperation` to a union of the two user operation types. Likewise for the related types like `UserOperationPartial`.