### PR TITLE
Fix polygon chain id

### DIFF
--- a/parser/index.ts
+++ b/parser/index.ts
@@ -201,7 +201,7 @@ function extractChainAndNetworks(
       if (parts.length !== 2) {
         throw new Error('Should have 2 parts');
       }
-      const chain = parts[0];
+      const chain = parts[0] === 'polygon' ? 'matic' : parts[0];
       const network = parts[1];
 
       const networks = chainsToNetworks.get(chain);


### PR DESCRIPTION
We recently changed the underlying chain id for Polygon from "polygon" to "matic". 
This pull request makes the change in the parser.