### PR TITLE
[Docs] Fix: getTokenBalanceByWallet OpenAPI was using vitalik address…

### DIFF
--- a/evm_body.yaml
+++ b/evm_body.yaml
@@ -838,7 +838,7 @@ alchemy_getTokenBalances:
             3. Options (optional) - An object that contains the following settings **[omitted below]**:
                 1. `pageKey`: Applies only to the `erc20` request type. A string address used for pagination. If more results are available, a `pageKey` will be returned in the response.
                 2. `maxCount`: Applies only to the `erc20` request type. Specifies the maximum count of token balances to return per call. This value defaults to 100 and is currently capped at 100.
-          minItems: 2
+          minItems: 1
           maxItems: 3
           items:
             oneOf:
@@ -882,6 +882,8 @@ alchemy_getTokenBalances:
                   items:
                     type: string
                     pattern: '^0[xX][0-9a-fA-F]+$'
+                  example: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48']
+                  default: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48']
             - type: object
               title: Options
               properties:


### PR DESCRIPTION
… for both params

Updated schema so that `curl` request preview uses Vitalik address as first param and USDC address as second param.

Also lowered the min param count to 1.

<img width="460" alt="image" src="https://github.com/user-attachments/assets/899eae9b-40ad-49cb-b921-96b34fad42e3" />

Reported by Peter.