### PR TITLE
Docs on call request: add supported chains to `debug_` methods

### DIFF
--- a/debug/debug_traceBlockByHash.yaml
+++ b/debug/debug_traceBlockByHash.yaml
@@ -11,22 +11,76 @@ servers:
           - eth-sepolia
           - eth-holesky
           - opt-mainnet
+          - opt-sepolia
           - polygon-mainnet
           - polygon-amoy
+          - polygonzkevm-mainnet
+          - polygonzkevm-cardona
+          - apechain-mainnet
+          - apechain-curtis
           - arb-mainnet
           - arb-sepolia
+          - astar-mainnet
+          - avax-mainnet
+          - avax-fuji
           - arbnova-mainnet
+          - abstract-mainnet
+          - abstract-testnet
           - base-mainnet
           - base-sepolia
+          - berachain-mainnet
           - bob-mainnet
+          - blast-sepolia
+          - bnb-mainnet
+          - celo-mainnet
+          - crossfi-mainnet
+          - crossfi-testnet
+          - degen-mainnet
+          - fantom-testnet
+          - flow-mainnet
+          - geist-mainnet
+          - geist-polter
+          - gnosis-chiado
+          - k2-testnet
+          - kinto-mainnet
           - spotlight-mainnet
           - spotlight-sepolia
           - xmtp-testnet
           - chiliz-mainnet
           - chiliz-spicy
-          - abstract-testnet
+          - ink-mainnet
+          - ink-sepolia
+          - metis-mainnet
+          - moonbeam-mainnet
+          - monad-testnet
+          - lens-mainnet
+          - lens-sepolia
+          - linea-mainnet
+          - opbnb-mainnet
+          - openloot-sepolia
+          - rootstock-mainnet
+          - rootstock-testnet
+          - ronin-mainnet
+          - ronin-saigon
+          - sei-mainnet
+          - sei-testnet
+          - scroll-mainnet
+          - scroll-sepolia
           - shape-mainnet
-          - shape-sepolia
+          - soneium-mainnet
+          - soneium-minato
+          - sonic-blaze
+          - superseed-mainnet
+          - tea-sepolia
+          - unichain-mainnet
+          - unichain-sepolia
+          - worldchain-mainnet
+          - worldchain-sepolia
+          - xmtp-testnet
+          - zetachain-mainnet
+          - zetachain-testnet
+          - zksync-mainnet
+          - zksync-sepolia
         default: eth-mainnet
 x-sandbox:
   category:

--- a/debug/debug_traceBlockByNumber.yaml
+++ b/debug/debug_traceBlockByNumber.yaml
@@ -11,22 +11,45 @@ servers:
           - eth-sepolia
           - eth-holesky
           - opt-mainnet
+          - opt-sepolia
           - polygon-mainnet
           - polygon-amoy
           - arb-mainnet
           - arb-sepolia
           - arbnova-mainnet
+          - abstract-mainnet
+          - abstract-testnet
           - base-mainnet
           - base-sepolia
+          - berachain-bartio
           - bob-mainnet
+          - bob-sepolia
+          - crossfi-mainnet
+          - crossfi-testnet
+          - k2-testnet
           - spotlight-mainnet
           - spotlight-sepolia
           - xmtp-testnet
           - chiliz-mainnet
           - chiliz-spicy
-          - abstract-testnet
+          - ink-mainnet
+          - ink-sepolia
+          - metabased-stratos
+          - ronin-mainnet
+          - ronin-saigon
+          - sei-mainnet
+          - sei-testnet
           - shape-mainnet
           - shape-sepolia
+          - soneium-mainnet
+          - soneium-minato
+          - sonic-mainnet
+          - sonic-blaze
+          - superseed-mainnet
+          - superseed-sepolia
+          - unichain-mainnet
+          - unichain-sepolia
+          - xmtp-testnet
         default: eth-mainnet
 x-sandbox:
   category:

--- a/debug/debug_traceBlockByNumber.yaml
+++ b/debug/debug_traceBlockByNumber.yaml
@@ -14,19 +14,35 @@ servers:
           - opt-sepolia
           - polygon-mainnet
           - polygon-amoy
+          - polygonzkevm-mainnet
+          - polygonzkevm-cardona
+          - apechain-mainnet
+          - apechain-curtis
           - arb-mainnet
           - arb-sepolia
+          - astar-mainnet
+          - avax-mainnet
+          - avax-fuji
           - arbnova-mainnet
           - abstract-mainnet
           - abstract-testnet
           - base-mainnet
           - base-sepolia
-          - berachain-bartio
+          - berachain-mainnet
           - bob-mainnet
-          - bob-sepolia
+          - blast-sepolia
+          - bnb-mainnet
+          - celo-mainnet
           - crossfi-mainnet
           - crossfi-testnet
+          - degen-mainnet
+          - fantom-testnet
+          - flow-mainnet
+          - geist-mainnet
+          - geist-polter
+          - gnosis-chiado
           - k2-testnet
+          - kinto-mainnet
           - spotlight-mainnet
           - spotlight-sepolia
           - xmtp-testnet
@@ -34,22 +50,37 @@ servers:
           - chiliz-spicy
           - ink-mainnet
           - ink-sepolia
-          - metabased-stratos
+          - metis-mainnet
+          - moonbeam-mainnet
+          - monad-testnet
+          - lens-mainnet
+          - lens-sepolia
+          - linea-mainnet
+          - opbnb-mainnet
+          - openloot-sepolia
+          - rootstock-mainnet
+          - rootstock-testnet
           - ronin-mainnet
           - ronin-saigon
           - sei-mainnet
           - sei-testnet
+          - scroll-mainnet
+          - scroll-sepolia
           - shape-mainnet
-          - shape-sepolia
           - soneium-mainnet
           - soneium-minato
-          - sonic-mainnet
           - sonic-blaze
           - superseed-mainnet
-          - superseed-sepolia
+          - tea-sepolia
           - unichain-mainnet
           - unichain-sepolia
+          - worldchain-mainnet
+          - worldchain-sepolia
           - xmtp-testnet
+          - zetachain-mainnet
+          - zetachain-testnet
+          - zksync-mainnet
+          - zksync-sepolia
         default: eth-mainnet
 x-sandbox:
   category:

--- a/debug/debug_traceCall.yaml
+++ b/debug/debug_traceCall.yaml
@@ -11,22 +11,76 @@ servers:
           - eth-sepolia
           - eth-holesky
           - opt-mainnet
+          - opt-sepolia
           - polygon-mainnet
           - polygon-amoy
+          - polygonzkevm-mainnet
+          - polygonzkevm-cardona
+          - apechain-mainnet
+          - apechain-curtis
           - arb-mainnet
           - arb-sepolia
+          - astar-mainnet
+          - avax-mainnet
+          - avax-fuji
           - arbnova-mainnet
+          - abstract-mainnet
+          - abstract-testnet
           - base-mainnet
           - base-sepolia
+          - berachain-mainnet
           - bob-mainnet
+          - blast-sepolia
+          - bnb-mainnet
+          - celo-mainnet
+          - crossfi-mainnet
+          - crossfi-testnet
+          - degen-mainnet
+          - fantom-testnet
+          - flow-mainnet
+          - geist-mainnet
+          - geist-polter
+          - gnosis-chiado
+          - k2-testnet
+          - kinto-mainnet
           - spotlight-mainnet
           - spotlight-sepolia
           - xmtp-testnet
           - chiliz-mainnet
           - chiliz-spicy
-          - abstract-testnet
+          - ink-mainnet
+          - ink-sepolia
+          - metis-mainnet
+          - moonbeam-mainnet
+          - monad-testnet
+          - lens-mainnet
+          - lens-sepolia
+          - linea-mainnet
+          - opbnb-mainnet
+          - openloot-sepolia
+          - rootstock-mainnet
+          - rootstock-testnet
+          - ronin-mainnet
+          - ronin-saigon
+          - sei-mainnet
+          - sei-testnet
+          - scroll-mainnet
+          - scroll-sepolia
           - shape-mainnet
-          - shape-sepolia
+          - soneium-mainnet
+          - soneium-minato
+          - sonic-blaze
+          - superseed-mainnet
+          - tea-sepolia
+          - unichain-mainnet
+          - unichain-sepolia
+          - worldchain-mainnet
+          - worldchain-sepolia
+          - xmtp-testnet
+          - zetachain-mainnet
+          - zetachain-testnet
+          - zksync-mainnet
+          - zksync-sepolia
         default: eth-mainnet
 x-sandbox:
   category:

--- a/debug/debug_traceTransaction.yaml
+++ b/debug/debug_traceTransaction.yaml
@@ -11,22 +11,76 @@ servers:
           - eth-sepolia
           - eth-holesky
           - opt-mainnet
+          - opt-sepolia
           - polygon-mainnet
           - polygon-amoy
+          - polygonzkevm-mainnet
+          - polygonzkevm-cardona
+          - apechain-mainnet
+          - apechain-curtis
           - arb-mainnet
           - arb-sepolia
+          - astar-mainnet
+          - avax-mainnet
+          - avax-fuji
           - arbnova-mainnet
+          - abstract-mainnet
+          - abstract-testnet
           - base-mainnet
           - base-sepolia
+          - berachain-mainnet
           - bob-mainnet
+          - blast-sepolia
+          - bnb-mainnet
+          - celo-mainnet
+          - crossfi-mainnet
+          - crossfi-testnet
+          - degen-mainnet
+          - fantom-testnet
+          - flow-mainnet
+          - geist-mainnet
+          - geist-polter
+          - gnosis-chiado
+          - k2-testnet
+          - kinto-mainnet
           - spotlight-mainnet
           - spotlight-sepolia
           - xmtp-testnet
           - chiliz-mainnet
           - chiliz-spicy
-          - abstract-testnet
+          - ink-mainnet
+          - ink-sepolia
+          - metis-mainnet
+          - moonbeam-mainnet
+          - monad-testnet
+          - lens-mainnet
+          - lens-sepolia
+          - linea-mainnet
+          - opbnb-mainnet
+          - openloot-sepolia
+          - rootstock-mainnet
+          - rootstock-testnet
+          - ronin-mainnet
+          - ronin-saigon
+          - sei-mainnet
+          - sei-testnet
+          - scroll-mainnet
+          - scroll-sepolia
           - shape-mainnet
-          - shape-sepolia
+          - soneium-mainnet
+          - soneium-minato
+          - sonic-blaze
+          - superseed-mainnet
+          - tea-sepolia
+          - unichain-mainnet
+          - unichain-sepolia
+          - worldchain-mainnet
+          - worldchain-sepolia
+          - xmtp-testnet
+          - zetachain-mainnet
+          - zetachain-testnet
+          - zksync-mainnet
+          - zksync-sepolia
         default: eth-mainnet
 x-sandbox:
   category:


### PR DESCRIPTION
Added supported chains, verified by Imply, to Top 4 `debug_` methods:
- `debug_traceBlockByNumber`
- `debug_traceBlockByHash`
- `debug_traceTransaction`
- `debug_traceCall`