### PR TITLE
chore: fix integer properties mislabeled as strings

### DIFF
--- a/nft/nfts.yaml
+++ b/nft/nfts.yaml
@@ -2411,8 +2411,8 @@ components:
       type: string
       description: "String - Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse when the metadata field is not automatically populated."
     totalNFTCount:
-      type: string
-      description: 'String - Total number of NFTs (distinct `tokenIds`) owned by the given address.'
+      type: integer
+      description: 'Integer - Total number of NFTs (distinct `tokenIds`) owned by the given address.'
     totalContractCount:
       type: string
       description: 'String - Total number of NFT contracts held by the given address returned in this page.'
@@ -2994,7 +2994,7 @@ components:
       description: Block Information of the block as of which the corresponding data is valid
       properties:
         blockNumber:
-          type: string
+          type: integer
           description: 'The block number above information is valid as of'
         blockHash:
           type: string


### PR DESCRIPTION
Coinbase pointed out a few integer properties on getNftsForOwner are mislabeled as strings in the docs: https://alchemyinsights.slack.com/archives/C03306R8XTL/p1743719868319129

URL for test project: https://test-base.readme.io/reference/getnftsforowner-v3-10